### PR TITLE
Task/eslint products config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,7 +76,8 @@
                 "declaration": "parens-new-line"
             }
         ],
-        "react/jsx-closing-bracket-location": "error"
+        "react/jsx-closing-bracket-location": "error",
+        "wpcalypso/import-docblock": "warn"
     },
     "globals": {
         "wp": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,10 @@
         "browser": true,
         "es6": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "products/react"
+    ],
+    "parser": "babel-eslint",
     "parserOptions": {
         "ecmaFeatures": {
             "experimentalObjectRestSpread": true,
@@ -11,9 +14,6 @@
         },
         "sourceType": "module"
     },
-    "plugins": [
-        "react"
-    ],
     "rules": {
         "indent": [
             "error",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"css-loader": "0.28.9",
 		"css-mqpacker": "^4.0.1",
 		"eslint": "^4.19.1",
+		"eslint-config-products": "github:moderntribe/eslint-config-products#v0.1.0",
 		"eslint-plugin-react": "^7.7.0",
 		"extract-text-webpack-plugin": "3.0.0",
 		"gettext-parser": "1.3.0",


### PR DESCRIPTION
Fixes #48 

This adds in our eslint config for products. Also, updated eslint parser for be `babel-eslint` so it could parse static types in some components