### PR TITLE
Fix/108306 dashboard closing issue

### DIFF
--- a/src/modules/elements/dashboard/element.js
+++ b/src/modules/elements/dashboard/element.js
@@ -133,7 +133,7 @@ export default class Dashboard extends Component {
 	 */
 	onClickOutside = ( event ) => {
 		const { target } = event;
-		if ( this.isPartOfDashboard( target ) ) {
+		if ( Dashboard.isPartOfDashboard( target ) || Dashboard.isPartOfSidebar( target ) ) {
 			return;
 		}
 		this.close();
@@ -146,11 +146,17 @@ export default class Dashboard extends Component {
 	 * @param {DomNode} node - The element tested against
 	 * @returns {boolean} True if the element clicked is part of the dashboard
 	 */
-	isPartOfDashboard( node ) {
+	static isPartOfDashboard( node ) {
 		return searchParent( node, ( testNode ) => {
 			const isContainer = testNode.classList.contains( 'tribe-editor__dashboard__container' );
 			const isDashboard = testNode.classList.contains( 'tribe-editor__dashboard' );
 			return isDashboard || isContainer;
+		} );
+	}
+
+	static isPartOfSidebar( node ) {
+		return searchParent( node, ( testNode ) => {
+			return testNode.classList.contains( 'edit-post-sidebar' );
 		} );
 	}
 

--- a/src/modules/elements/dashboard/element.js
+++ b/src/modules/elements/dashboard/element.js
@@ -133,7 +133,11 @@ export default class Dashboard extends Component {
 	 */
 	onClickOutside = ( event ) => {
 		const { target } = event;
-		if ( Dashboard.isPartOfDashboard( target ) || Dashboard.isPartOfSidebar( target ) ) {
+		if (
+			Dashboard.isPartOfDashboard( target ) ||
+			Dashboard.isPartOfPopover( target ) ||
+			Dashboard.isPartOfSidebar( target )
+		) {
 			return;
 		}
 		this.close();
@@ -154,10 +158,19 @@ export default class Dashboard extends Component {
 		} );
 	}
 
+	/**
+	 * Listen for a click on the document to see if the element is part of the Popover component
+	 * if not we should close
+	 *
+	 * @param {DomNode} node - The element tested against
+	 * @returns {boolean} True if the element clicked is part of the popover component
+	 */
+	static isPartOfPopover( node ) {
+		return searchParent( node, testNode => testNode.classList.contains( 'components-popover' ) );
+	}
+
 	static isPartOfSidebar( node ) {
-		return searchParent( node, ( testNode ) => {
-			return testNode.classList.contains( 'edit-post-sidebar' );
-		} );
+		return searchParent( node, testNode => testNode.classList.contains( 'edit-post-sidebar' ) );
 	}
 
 	/**


### PR DESCRIPTION
@mitogh this is branched off your "closing dashboard when clicking on sidebar" branch, so review this once that branch is merged in.

On another note, I really dislike how WordPress handles its `Dropdown` component. If you look at the DOM, it is actually an absolutely positioned component **outside** of the edit post layout container and not a child or sibling of the actual button that opens and closes it. If possible, I'd be very much in favor of not using the `Dropdown` component.

For ticket: https://central.tri.be/issues/108306