### PR TITLE
Create a CSS base to work our FE views.

### DIFF
--- a/events-gutenberg.php
+++ b/events-gutenberg.php
@@ -67,6 +67,10 @@ class Tribe__Events_Gutenberg__Plugin {
 
 		// Register the Service Provider
 		tribe_register_provider( 'Tribe__Events_Gutenberg__Provider' );
+
+		// Assets loader
+		tribe_singleton( 'gutenberg.assets', 'Tribe__Events_Gutenberg__Assets', array( 'register', 'hook' ) );
+		tribe( 'gutenberg.assets' );
 	}
 
 	/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Events Gutenberg Assets
+ *
+ * @since TBD
+ */
+class Tribe__Events_Gutenberg__Assets {
+	/**
+	 *
+	 * @since  TBD
+	 *
+	 * @return void
+	 */
+	public function hook() {
+
+	}
+
+	/**
+	 * Registers and Enqueues the assets
+	 *
+	 * @since  TBD
+	 *
+	 * @param string $key Which key we are checking against
+	 *
+	 * @return boolean
+	 */
+	public function register() {
+
+		$plugin = tribe( 'gutenberg' );
+
+		tribe_asset(
+			$plugin,
+			'tribe-events-gutenberg-views',
+			'views.css',
+			array(),
+			'wp_enqueue_scripts',
+			array(
+				'groups'       => array( 'events-views' ),
+				'conditionals' => array( $this, 'should_enqueue_frontend' ),
+			)
+		);
+
+	}
+
+	/**
+	 * Checks if we should enqueue frontend assets
+	 *
+	 * @since  TBD
+	 *
+	 * @return bool
+	 */
+	public function should_enqueue_frontend() {
+		$should_enqueue = (
+			tribe_is_event_query()
+			|| tribe_is_event_organizer()
+			|| tribe_is_event_venue()
+			|| is_active_widget( false, false, 'tribe-events-list-widget' )
+		);
+
+		/**
+		 * Allow filtering of where the base Frontend Assets will be loaded
+		 *
+		 * @since  TBD
+		 *
+		 * @param bool $should_enqueue
+		 */
+		return apply_filters( 'tribe_events_gutenberg_assets_should_enqueue_frontend', $should_enqueue );
+	}
+}

--- a/src/modules/views/classic-event-details/style.pcss
+++ b/src/modules/views/classic-event-details/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Classic Event Details block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-category/style.pcss
+++ b/src/modules/views/event-category/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Event Category block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-datetime/style.pcss
+++ b/src/modules/views/event-datetime/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Event Date & Time block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-links/style.pcss
+++ b/src/modules/views/event-links/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Event Links block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-organizer/style.pcss
+++ b/src/modules/views/event-organizer/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Organizer block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-price/style.pcss
+++ b/src/modules/views/event-price/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Event Price block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-tags/style.pcss
+++ b/src/modules/views/event-tags/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Event Tags block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-venue/style.pcss
+++ b/src/modules/views/event-venue/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Venue block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/event-website/style.pcss
+++ b/src/modules/views/event-website/style.pcss
@@ -1,0 +1,5 @@
+/**
+ * Website block view styles
+ *
+ * @since  TBD
+ */

--- a/src/modules/views/index.js
+++ b/src/modules/views/index.js
@@ -1,0 +1,13 @@
+// General FE styles
+import './style.pcss';
+
+// Import each block view
+import './classic-event-details/style.pcss';
+import './event-datetime/style.pcss';
+import './event-venue/style.pcss';
+import './event-organizer/style.pcss';
+import './event-links/style.pcss';
+import './event-price/style.pcss';
+import './event-category/style.pcss';
+import './event-tags/style.pcss';
+import './event-website/style.pcss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const entryPointNames = [
 	'elements',
 	'editor',
 	'blocks',
+	'views',
 ];
 
 const alias = entryPointNames.reduce( ( memo, entryPointName ) => {


### PR DESCRIPTION
🎫 https://central.tri.be/issues/108763

The idea of these changes is to define a structure where we can have a file for each block view. These files will be bundled into `resoruces/css/views.css` (in the future ideally minified) and will serve as a base to give the basic styles of the different blocks.

Added the `Assets` class in order to manage this, and enqueue on the FE.