### PR TITLE
Prevent to create multiple entries and remove publish posts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 * Tweak - Remove references to `withSelect` and `withDispatch` and replace with `connect`
 * Tweak - Prevent errors when a new organizer block is created
 * Tweak - `showMap` and `showMapLink` are enabled by default on Location block
+* Fix - Prevent to create multiples entries when using sync copies of blocks
 * Feature - HOC `withDetails` to fetch details of a post type.
 * Feature - HOC `withForm` to attach Form behaviors into a block.
 * Feature - HOC `withStore` to inject the store property into a component

--- a/src/modules/blocks/event-organizer/block.js
+++ b/src/modules/blocks/event-organizer/block.js
@@ -173,7 +173,7 @@ class Organizer extends Component {
 			organizer,
 			removeOrganizerInBlock,
 			volatile,
-			removeEntry,
+			maybeRemoveEntry,
 			removeOrganizerInClassic,
 			details,
 		} = this.props;
@@ -181,7 +181,7 @@ class Organizer extends Component {
 		removeOrganizerInBlock( id, organizer );
 
 		if ( volatile ) {
-			removeEntry( details );
+			maybeRemoveEntry( details );
 			removeOrganizerInClassic( organizer );
 		}
 	};

--- a/src/modules/blocks/event-venue/block.js
+++ b/src/modules/blocks/event-venue/block.js
@@ -264,10 +264,10 @@ class EventVenue extends Component {
 	}
 
 	removeVenue = () => {
-		const { volatile, removeEntry, removeVenue, details } = this.props;
+		const { volatile, maybeRemoveEntry, removeVenue, details } = this.props;
 		removeVenue();
 		if ( volatile ) {
-			removeEntry( details );
+			maybeRemoveEntry( details );
 		}
 	};
 

--- a/src/modules/data/forms/reducer.js
+++ b/src/modules/data/forms/reducer.js
@@ -17,6 +17,7 @@ const byId = ( state = {}, action ) => {
 		case types.CREATE_FORM_DRAFT:
 		case types.EDIT_FORM_ENTRY:
 		case types.SUBMIT_FORM:
+		case types.SET_SAVING_FORM:
 			return {
 				...state,
 				[ action.payload.id ]: form( state[ action.payload.id ], action ),

--- a/src/modules/data/forms/reducers/form.js
+++ b/src/modules/data/forms/reducers/form.js
@@ -8,6 +8,7 @@ export const DEFAULT_STATE = {
 	edit: false,
 	create: false,
 	submit: false,
+	saving: false,
 	fields: {},
 	type: EVENT,
 };
@@ -32,6 +33,11 @@ export default ( state = DEFAULT_STATE, action ) => {
 				edit: false,
 				create: true,
 				fields: action.payload.fields,
+			};
+		case types.SET_SAVING_FORM:
+			return {
+				...state,
+				saving: action.payload.saving,
 			};
 		case types.EDIT_FORM_ENTRY:
 			return {

--- a/src/modules/data/forms/selectors.js
+++ b/src/modules/data/forms/selectors.js
@@ -31,4 +31,9 @@ export const getFormFields = createSelector(
 	( block ) => block ? block.fields : DEFAULT_STATE.fields,
 );
 
+export const getFormSaving = createSelector(
+	[ formSelector ],
+	( block ) => block ? block.saving : DEFAULT_STATE.saving
+);
+
 export const getVolatile = ( state ) => state.forms.volatile;

--- a/src/modules/data/forms/types.js
+++ b/src/modules/data/forms/types.js
@@ -4,6 +4,7 @@ export const CREATE_FORM_DRAFT = 'CREATE_FORM_DRAFT';
 export const EDIT_FORM_ENTRY = 'EDIT_FORM_ENTRY';
 export const SUBMIT_FORM = 'SUBMIT_FORM';
 export const CLEAR_FORM = 'CLEAR_FORM';
+export const SET_SAVING_FORM = 'SET_SAVING_FORM';
 
 export const ADD_VOLATILE_ID = 'ADD_VOLATILE_ID';
 export const REMOVE_VOLATILE_ID = 'REMOVE_VOLATILE_ID';

--- a/src/modules/editor/hoc/with-form.js
+++ b/src/modules/editor/hoc/with-form.js
@@ -38,7 +38,7 @@ export default ( args ) => ( WrappedComponent ) => {
 				sendForm,
 				setSubmit,
 				editEntry,
-				removeEntry,
+				maybeRemoveEntry,
 			} = this.props;
 			const name = args( this.props );
 			return {
@@ -54,8 +54,8 @@ export default ( args ) => ( WrappedComponent ) => {
 				setSubmit() {
 					setSubmit( name );
 				},
-				removeEntry( details ) {
-					removeEntry( name, details );
+				maybeRemoveEntry( details ) {
+					maybeRemoveEntry( name, details );
 				},
 			};
 		}


### PR DESCRIPTION
- Prevent to create multiple entries of a Venue if multiple blocks of the same block are created using the "sync" block type
- Prevent to remove venues or organizers when the event has been publish and they are marked as `volatile` still.