### PR TITLE
Fix count of blocks of the same type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,13 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 * Fix - Styles for map container and fix map error
 * Fix - Issue on `datetime` block to select the date on Gutenberg 3.1
+* Fix - Prevent to create multiples entries when using sync copies of blocks
+* Fix - Problem when multiple sync copies were not initialized
 * Tweak - Consolidate multiple stores into a single store
 * Tweak - Use native redux store implementation
 * Tweak - Remove references to `withSelect` and `withDispatch` and replace with `connect`
 * Tweak - Prevent errors when a new organizer block is created
 * Tweak - `showMap` and `showMapLink` are enabled by default on Location block
-* Fix - Prevent to create multiples entries when using sync copies of blocks
 * Feature - HOC `withDetails` to fetch details of a post type.
 * Feature - HOC `withForm` to attach Form behaviors into a block.
 * Feature - HOC `withStore` to inject the store property into a component

--- a/src/modules/editor/hoc/with-form.js
+++ b/src/modules/editor/hoc/with-form.js
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { compose, bindActionCreators } from 'redux';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
@@ -74,5 +74,5 @@ export default ( args ) => ( WrappedComponent ) => {
 
 	const mapDispatchToProps = ( dispatch ) => bindActionCreators( actions, dispatch );
 
-	return compose( connect( mapStateToProps, mapDispatchToProps ) )( WithForm );
+	return connect( mapStateToProps, mapDispatchToProps )( WithForm );
 };


### PR DESCRIPTION
Prevent the initialization of blocks that are of the same type and are not isolated, which means they should be initialized only once per block