### PR TITLE
Fix default timezone value when new event was created

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 * Fix - Issue on `datetime` block to select the date on Gutenberg 3.1
 * Fix - Prevent to create multiples entries when using sync copies of blocks
 * Fix - Problem when multiple sync copies were not initialized
+* Fix - Use default timezone selected by the user on the admin instead of `UTC`
 * Tweak - Consolidate multiple stores into a single store
 * Tweak - Use native redux store implementation
 * Tweak - Remove references to `withSelect` and `withDispatch` and replace with `connect`

--- a/src/modules/data/blocks/datetime/reducers.js
+++ b/src/modules/data/blocks/datetime/reducers.js
@@ -12,6 +12,7 @@ import moment from 'moment/moment';
  * Internal dependencies
  */
 import { HALF_HOUR_IN_SECONDS } from 'editor/utils/time';
+import { FORMATS } from 'editor/utils/date';
 import { roundTime, toDateTime } from 'editor/utils/moment';
 import { getSetting } from 'editor/settings';
 import * as types from './types';
@@ -23,7 +24,7 @@ export const DEFAULT_STATE = {
 	timeRangeSeparator: getSetting( 'timeRangeSeparator', __( '-', 'events-gutenberg' ) ),
 	allDay: false,
 	multiDay: false,
-	timezone: 'UTC',
+	timezone: FORMATS.TIMEZONE.string,
 };
 
 export default ( state = DEFAULT_STATE, action ) => {

--- a/src/modules/editor/utils/date.js
+++ b/src/modules/editor/utils/date.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
  */
 
 const WPDateSettings = get( window, 'tribe_date_settings', {} );
-const { formats } = WPDateSettings;
+const { formats = {}, timezone = {} } = WPDateSettings;
 
 export const FORMATS = {
 	TIME: 'HH:mm:ss',
@@ -17,6 +17,10 @@ export const FORMATS = {
 		datetime: 'F j, Y g:i a',
 		dateNoYear: 'F j',
 		...formats,
+	},
+	TIMEZONE: {
+		string: 'UTC',
+		...timezone,
 	},
 };
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/103751