### PR TITLE
Add "Event Blocks" category to the editor.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 #### 0.2.5-alpha - TBD
 * Tweak - Change event location to event venue
 * Tweak - Add tests for utils functions
+* Tweak - Add "Event Blocks" category to the editor
 
 #### 0.2.4-alpha - 2018-07-12
 

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -512,6 +512,31 @@ class Tribe__Events_Gutenberg__Editor {
 		);
 	}
 
+	/**
+	 * Add "Event Blocks" category to the editor
+	 *
+	 * @since  TBD
+	 *
+	 * @return array
+	 */
+	public function block_categories( $categories, $post ) {
+
+		if ( Tribe__Events__Main::POSTTYPE !== $post->post_type ) { // @TODO: make compatible with standalone ET options in the future
+			return $categories;
+		}
+
+		return array_merge(
+			$categories,
+			array(
+				array(
+					'slug'  => 'tribe-events',
+					'title' => __( 'Event Blocks', 'events-gutenberg' ),
+				),
+			)
+		);
+
+	}
+
 	/************************
 	 *                      *
 	 *  Deprecated Methods  *

--- a/src/Tribe/Provider.php
+++ b/src/Tribe/Provider.php
@@ -105,6 +105,9 @@ class Tribe__Events_Gutenberg__Provider extends tad_DI52_ServiceProvider {
 		// Maybe add flag from classic editor
 		add_action( 'init', tribe_callback( 'gutenberg.editor', 'flag_post_from_classic_editor' ), 0 );
 
+		// Add Block Categories to Editor
+		add_action( 'block_categories', tribe_callback( 'gutenberg.editor', 'block_categories' ), 10, 2 );
+
 		// Update Post content to use blocks
 		add_action( 'tribe_blocks_editor_flag_post_classic_editor', tribe_callback( 'gutenberg.editor', 'update_post_content_to_blocks' ) );
 

--- a/src/modules/blocks/classic-event-details/index.js
+++ b/src/modules/blocks/classic-event-details/index.js
@@ -25,7 +25,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-category/index.js
+++ b/src/modules/blocks/event-category/index.js
@@ -24,7 +24,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-datetime/index.js
+++ b/src/modules/blocks/event-datetime/index.js
@@ -25,7 +25,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-links/index.js
+++ b/src/modules/blocks/event-links/index.js
@@ -25,7 +25,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-organizer/index.js
+++ b/src/modules/blocks/event-organizer/index.js
@@ -21,7 +21,7 @@ export default {
 	title: __( 'Event Organizer', 'events-gutenberg' ),
 	description: __( 'List a host or coordinator for this event.', 'events-gutenberg' ),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-price/index.js
+++ b/src/modules/blocks/event-price/index.js
@@ -25,7 +25,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-venue/index.js
+++ b/src/modules/blocks/event-venue/index.js
@@ -22,7 +22,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {

--- a/src/modules/blocks/event-website/index.js
+++ b/src/modules/blocks/event-website/index.js
@@ -25,7 +25,7 @@ export default {
 		'events-gutenberg'
 	),
 	icon: Icons.TEC,
-	category: 'common',
+	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 
 	supports: {


### PR DESCRIPTION
🎫 https://central.tri.be/issues/110898

Adding the "Events Block" category to the editor. 

Blocks included: Event Date & Time, Event Details Classic, Event Organizer, Event Venue, Event Sharing, Event Categories, Event Website, Event Price.