### PR TITLE
Normalize styles for the Event Options metabox

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 * Tweak - Change event location to event venue
 * Tweak - Add tests for utils functions
 * Tweak - Add "Event Blocks" category to the editor
+* Tweak - Normalize styles for the Event Options metabox
 
 #### 0.2.4-alpha - 2018-07-12
 

--- a/src/modules/editor/style.pcss
+++ b/src/modules/editor/style.pcss
@@ -78,3 +78,22 @@
 		box-sizing: border-box;
 	}
 }
+
+.edit-post-meta-boxes-area {
+	#tribe_events_event_options {
+		h2 {
+			&.hndle {
+				border-bottom: none;
+				span {
+					color: #191e23;
+					font-size: 13px;
+				}
+			}
+		}
+		.handlediv {
+			.toggle-indicator {
+				color: #191e23;
+			}
+		}
+	}
+}

--- a/src/modules/editor/style.pcss
+++ b/src/modules/editor/style.pcss
@@ -90,6 +90,7 @@
 				}
 			}
 		}
+
 		.handlediv {
 			.toggle-indicator {
 				color: #191e23;


### PR DESCRIPTION
🎫 https://central.tri.be/issues/110895

As required in the ticket: Normalize styles for the Event Options metabox