### PR TITLE
Remove clear button from time inputs (webkit)

### DIFF
--- a/src/modules/elements/time-picker/style.pcss
+++ b/src/modules/elements/time-picker/style.pcss
@@ -14,6 +14,11 @@
 	input[type="time"] {
 		padding: 6px 0;
 		border: none;
+
+		&::-webkit-clear-button {
+			-webkit-appearance: none;
+			display: none;
+		}
 	}
 
 	button {


### PR DESCRIPTION
🎫 https://central.tri.be/issues/111176

Remove the X button from the date input. Currently, the only available solution (besides setting the field as required, and as we re-use that block I'm not sure if it's the best solution right now).

There's no current solution for Firefox.