### PR TITLE
Display currency in price block preview

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 * Tweak - Add tests for utils functions
 * Tweak - Add "Event Blocks" category to the editor
 * Tweak - Normalize styles for the Event Options metabox
+* Tweak - Display the currency symbol and position in the event price block preview
 
 #### 0.2.4-alpha - 2018-07-12
 

--- a/src/modules/blocks/event-price/template.js
+++ b/src/modules/blocks/event-price/template.js
@@ -37,8 +37,13 @@ const renderCurrency = ({ showCurrencySymbol, currencySymbol }) => (
 	)
 );
 
-const renderPlaceholder = ({ showCost }) => {
-	const placeholder = __( 'Add Price', 'events-gutenberg' );
+const renderPlaceholder = ({ showCost, currencySymbol, currencyPosition }) => {
+	let placeholder = __( 'Add Price', 'events-gutenberg' );
+
+	placeholder = ( 'prefix' === currencyPosition ) ?
+		currencySymbol + ' ' + placeholder :
+		placeholder + ' ' + currencySymbol;
+
 
 	return ! showCost && (
 		<span className="tribe-editor__event-price__label">{ placeholder }</span>


### PR DESCRIPTION
🎫 https://central.tri.be/issues/111156

Display the currency and its position (both if defined) in the price block preview