### PR TITLE
Rename the "Event Tags" block and label to "Tags"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,12 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 ### Changelog
 
+#### 0.2.6-alpha - TBD
+
+* Tweak - Rename the "Event Tags" block and label to "Tags"
+
+* Feature - Frontend view for date time block
+
 #### 0.2.5-alpha - 2018-08-04
 
 * Feature - Frontend view for date time block

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,6 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 * Tweak - Rename the "Event Tags" block and label to "Tags"
 
-* Feature - Frontend view for date time block
-
 #### 0.2.5-alpha - 2018-08-04
 
 * Feature - Frontend view for date time block

--- a/src/modules/blocks/event-tags/block.js
+++ b/src/modules/blocks/event-tags/block.js
@@ -51,7 +51,7 @@ export default class EventTags extends Component {
 		return (
 			<TermsList
 				slug="tags"
-				label={ __( 'Event Tags', 'events-gutenberg' ) }
+				label={ __( 'Tags', 'events-gutenberg' ) }
 				renderEmpty={ __( 'Add tags in document settings', 'events-gutenberg' ) }
 			/>
 		);

--- a/src/modules/blocks/event-tags/index.js
+++ b/src/modules/blocks/event-tags/index.js
@@ -18,7 +18,7 @@ import { Icons } from 'elements';
  */
 export default {
 	id: 'event-tags',
-	title: __( 'Event Tags', 'events-gutenberg' ),
+	title: __( 'Tags', 'events-gutenberg' ),
 	description: __( 'Add keywords by displaying linked tags.', 'events-gutenberg' ),
 	icon: Icons.TEC,
 	category: 'common',


### PR DESCRIPTION
🎫 https://central.tri.be/issues/111173

Rename the "Event Tags" block and label to "Tags" 🏷 