### PR TITLE
Use global timezone as default label

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,10 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 ### Changelog
 
+#### 0.2.7-alpha - TBD
+
+* Tweak - Use event timezone as default value
+
 #### 0.2.6-alpha - 2018-08-10
 
 * Tweak - Rename the "Event Tags" block and label to "Tags"

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -363,7 +363,7 @@ class Tribe__Events_Gutenberg__Editor {
 			'admin_url' => admin_url(),
 			'timeZone' => array(
 				'show_time_zone' => false,
-				'label' => '',
+				'label' => get_option( 'timezone_string', 'UTC' ),
 			),
 		);
 

--- a/src/modules/blocks/event-datetime/index.js
+++ b/src/modules/blocks/event-datetime/index.js
@@ -16,6 +16,7 @@ import EventDateTime from './block';
 import { Icons } from 'elements';
 import { config } from 'editor/utils/globals';
 const timeZone = get( config(), 'timeZone', {} );
+import { FORMATS } from 'editor/utils/date';
 
 /**
  * Module Code
@@ -72,7 +73,7 @@ export default {
 		},
 		timeZoneLabel: {
 			type: 'string',
-			default: get( timeZone, 'label', '' ),
+			default: get( timeZone, 'label', FORMATS.TIMEZONE.string ),
 		},
 		// Only Available for classic users
 		cost: {

--- a/src/modules/data/blocks/datetime/__tests__/thunks.test.js
+++ b/src/modules/data/blocks/datetime/__tests__/thunks.test.js
@@ -3,6 +3,7 @@
  */
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,8 +47,11 @@ describe( '[STORE] - Datetime thunks', () => {
 			timeZone: 'UTC',
 		};
 
-		store.dispatch( thunks.setInitialState( { attributes } ) );
+		const get = jest.fn( ( name ) => attributes[ name ] );
+		store.dispatch( thunks.setInitialState( { get, attributes } ) );
 
+		expect( get ).toHaveBeenCalled();
+		expect( get ).toHaveBeenCalledTimes( 2 );
 		expect( store.getActions() ).toMatchSnapshot();
 	} );
 
@@ -58,7 +62,8 @@ describe( '[STORE] - Datetime thunks', () => {
 			end: '',
 		};
 
-		store.dispatch( thunks.setInitialState( { attributes } ) );
+		const get = jest.fn( ( name ) => attributes[ name ] );
+		store.dispatch( thunks.setInitialState( { get, attributes } ) );
 
 		const types = store.getActions().map( ( action ) => action.type );
 		const values = store.getActions().map( ( action ) => action.payload )
@@ -71,6 +76,8 @@ describe( '[STORE] - Datetime thunks', () => {
 			'SET_NATURAL_LANGUAGE_LABEL',
 			'SET_MULTI_DAY',
 		];
+		expect( get ).toHaveBeenCalled();
+		expect( get ).toHaveBeenCalledTimes( 2 );
 		expect( types ).toEqual( expectedActions );
 		expect( values.start ).not.toBe( '' );
 		expect( values.end ).not.toBe( '' );

--- a/src/modules/data/blocks/datetime/thunks.js
+++ b/src/modules/data/blocks/datetime/thunks.js
@@ -97,7 +97,10 @@ export const setMultiDay = ( { start, end, isMultiDay } ) => ( dispatch ) => {
 	dispatch( setMultiDayAction( isMultiDay ) );
 };
 
-export const setInitialState = ( { attributes } ) => ( dispatch ) => {
+export const setInitialState = ( { get, attributes } ) => ( dispatch ) => {
+	const timeZone = get( 'timeZone', DEFAULT_STATE.timeZone );
+	const defaultTimeZone = get( 'timeZoneLabel', timeZone );
+
 	maybeBulkDispatch( attributes, dispatch )( [
 		[ setStart, 'start', DEFAULT_STATE.start ],
 		[ setEnd, 'end', DEFAULT_STATE.end ],
@@ -105,7 +108,7 @@ export const setInitialState = ( { attributes } ) => ( dispatch ) => {
 		[ setSeparatorDate, 'separatorDate', DEFAULT_STATE.dateTimeSeparator ],
 		[ setSeparatorTime, 'separatorTime', DEFAULT_STATE.timeRangeSeparator ],
 		[ setTimeZone, 'timeZone', DEFAULT_STATE.timeZone ],
-		[ setTimeZoneLabel, 'timeZoneLabel', DEFAULT_STATE.timeZoneLabel ],
+		[ setTimeZoneLabel, 'timeZoneLabel', defaultTimeZone ],
 		[ setTimeZoneVisibility, 'showTimeZone', DEFAULT_STATE.showTimeZone ],
 	] );
 


### PR DESCRIPTION
Set the global timezone if the attriubte is not present or as default value for the block attribute