### PR TITLE
Escape `pwd` to escape white spaces

### DIFF
--- a/plugins/common/scripts/linkDependencies
+++ b/plugins/common/scripts/linkDependencies
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-ln -sf $PWD/src/modules/hoc $PWD
+ln -sf "$(pwd)"/src/modules/hoc "$(pwd)"

--- a/plugins/events/scripts/linkDependencies
+++ b/plugins/events/scripts/linkDependencies
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-ln -sf $PWD/src/modules/blocks $PWD
-ln -sf $PWD/src/modules/data $PWD
-ln -sf $PWD/src/modules/editor $PWD
-ln -sf $PWD/src/modules/elements $PWD
+ln -sf "$(pwd)"/src/modules/blocks "$(pwd)"
+ln -sf "$(pwd)"/src/modules/data "$(pwd)"
+ln -sf "$(pwd)"/src/modules/editor "$(pwd)"
+ln -sf "$(pwd)"/src/modules/elements "$(pwd)"


### PR DESCRIPTION
Make sure when moving in directories characters of directories are escaped, such as spaces.