### PR TITLE
Use `common` method to format timezone

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 * Tweak - Use event timezone as default value
 * Tweak - Separate logic and presentation in event venue block
+* Fix - Display timezone label when selection is a UTC offset
 * Fix - Allow removal of organizers from classic block if the organizer block is removed
 
 #### 0.2.6-alpha - 2018-08-10

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -363,7 +363,7 @@ class Tribe__Events_Gutenberg__Editor {
 			'admin_url' => admin_url(),
 			'timeZone' => array(
 				'show_time_zone' => false,
-				'label' => get_option( 'timezone_string', 'UTC' ),
+				'label' => $this->get_timezone_label(),
 			),
 		);
 
@@ -540,9 +540,22 @@ class Tribe__Events_Gutenberg__Editor {
 			),
 			'timezone' => array(
 				'offset' => get_option( 'gmt_offset', 0 ),
-				'string' => get_option( 'timezone_string', 'UTC' ),
+				'string' => $this->get_timezone_label(),
 			),
 		);
+	}
+
+	/**
+	 * Returns the site timezone as a string
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_timezone_label() {
+		return class_exists( 'Tribe__Timezones' )
+			? Tribe__Timezones::wp_timezone_string()
+			: get_option( 'timezone_string', 'UTC' );
 	}
 
 	/**


### PR DESCRIPTION
In order to prevent empty string when a UTC or a UTC offset is selected