### PR TITLE
Remove organizer from classic editor if volatile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ This plugin is our first attempt at integrating the Event post type with the Gut
 
 * Tweak - Use event timezone as default value
 * Tweak - Separate logic and presentation in event venue block
+* Tweak - Make sure organizers are removed from classic editor when the organizer block is removed
 * Fix - Allow removal of organizers from classic block if the organizer block is removed
 
 #### 0.2.6-alpha - 2018-08-10

--- a/src/modules/blocks/event-organizer/container.js
+++ b/src/modules/blocks/event-organizer/container.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { withStore, withSaveData, withDetails, withForm } from 'editor/hoc';
 import { actions, selectors } from 'data/blocks/organizers';
 import { actions as detailsActions } from 'data/details';
+import { actions as formActions } from 'data/forms';
 import { ORGANIZER } from 'editor/post-types';
 import EventOrganizer from './template';
 import { toOrganizer } from 'elements/organizer-form/utils';
@@ -71,11 +72,21 @@ const mapDispatchToProps = ( dispatch ) => ( {
 		dispatch( actions.addOrganizerInClassic( organizer ) );
 	},
 	onBlockRemoved( props ) {
-		const { clientId, organizer } = props;
+		const { clientId, organizer, volatile } = props;
 		if ( ! organizer ) {
 			return;
 		}
+
 		dispatch( actions.removeOrganizerInBlock( clientId, organizer ) );
+
+		if ( volatile ) {
+			dispatch( actions.removeOrganizerInClassic( organizer ) );
+			/**
+			 * @todo: this one creates a connection with the Form event, however the form has no idea of
+			 * @todo: the ID to be removed so this one might be a good saga watcher
+			 */
+			dispatch( formActions.removeVolatile( organizer ) );
+		}
 	},
 } );
 


### PR DESCRIPTION
If an entry is volatile should be removed from classic editor when block removal