### PR TITLE
Feature/112919 block outside container

### DIFF
--- a/plugins/events/src/modules/blocks/event-website/template.js
+++ b/plugins/events/src/modules/blocks/event-website/template.js
@@ -10,7 +10,7 @@ import AutosizeInput from 'react-input-autosize';
  * WordPress dependencies
  */
 import { Dashicon } from '@wordpress/components';
-import { UrlInput } from '@wordpress/editor';
+import { URLInput } from '@wordpress/editor';
 import { sendValue } from '@moderntribe/events/editor/utils/input';
 import { __ } from '@wordpress/i18n';
 
@@ -29,7 +29,7 @@ const renderUrlInput = ({ isSelected, url, setWebsite }) => (
 	isSelected && (
 		<div key="tribe-events-website-url" className="tribe-editor__event-website__url">
 			<Dashicon icon="admin-links" />
-			<UrlInput
+			<URLInput
 				autoFocus={ false }
 				value={ url }
 				onChange={ setWebsite }

--- a/plugins/tickets/.gitignore
+++ b/plugins/tickets/.gitignore
@@ -1,1 +1,2 @@
+/elements
 /blocks

--- a/plugins/tickets/scripts/linkDependencies
+++ b/plugins/tickets/scripts/linkDependencies
@@ -1,3 +1,4 @@
 #! /bin/bash
 
 ln -sf "$(pwd)"/src/modules/blocks "$(pwd)"
+ln -sf "$(pwd)"/src/modules/elements "$(pwd)"

--- a/plugins/tickets/src/modules/elements/action-dashboard/element.js
+++ b/plugins/tickets/src/modules/elements/action-dashboard/element.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@moderntribe/tickets/elements'
+import './style.pcss';
+
+const ActionDashboard = ( {
+	actions,
+	cancelLabel,
+	className,
+	confirmLabel,
+	isCancelDisabled,
+	isConfirmDisabled,
+	onCancelClick,
+	onConfirmClick,
+	showCancel,
+	showConfirm,
+} ) => (
+	<section
+		className={ classnames(
+			'tribe-tickets__action-dashboard',
+			className,
+		) }
+	>
+		{ actions && actions.length && (
+			<div className="tribe-tickets__action-dashboard__group-left">
+				{ actions.map( ( action, index ) => (
+					<span
+						key={ `action-${index}`}
+						className="tribe-tickets__action-dashboard__action-wrapper"
+					>
+						{ action }
+					</span>
+				) ) }
+			</div>
+		) }
+		{ ( showCancel || showConfirm ) && (
+			<div className="tribe-tickets__action-dashboard__group-right">
+				{ showCancel && (
+					<Button
+						className="tribe-tickets__action-dashboard__cancel-button"
+						isDisabled={ isCancelDisabled }
+						label={ cancelLabel }
+						onClick={ onCancelClick }
+					/>
+				) }
+				{ showConfirm && (
+					<Button
+						className="tribe-tickets__action-dashboard__confirm-button"
+						isDisabled={ isConfirmDisabled }
+						label={ confirmLabel }
+						onClick={ onConfirmClick }
+					/>
+				) }
+			</div>
+		) }
+	</section>
+);
+
+ActionDashboard.defaultProps = {
+	showCancel: true,
+	showConfirm: true,
+};
+
+ActionDashboard.propTypes = {
+	actions: PropTypes.arrayOf( PropTypes.node ),
+	cancelLabel: PropTypes.string,
+	className: PropTypes.string,
+	confirmLabel: PropTypes.string,
+	isCancelDisabled: PropTypes.bool,
+	isConfirmDisabled: PropTypes.bool,
+	onCancelClick: PropTypes.func,
+	onConfirmClick: PropTypes.func,
+	showCancel: PropTypes.bool,
+	showConfirm: PropTypes.bool,
+};
+
+export default ActionDashboard;

--- a/plugins/tickets/src/modules/elements/action-dashboard/style.pcss
+++ b/plugins/tickets/src/modules/elements/action-dashboard/style.pcss
@@ -1,0 +1,57 @@
+.tribe-tickets__action-dashboard {
+	background-color: #f8f9fb;
+	display: flex;
+	margin: -14px -28px 0;
+	padding: 15px 17px 15px 20px;
+	position: relative;
+	bottom: -14px;
+}
+
+.tribe-tickets__action-dashboard__group-left {
+	display: flex;
+	align-items: center;
+	flex: 1;
+	justify-self: start;
+}
+
+.tribe-tickets__action-dashboard__group-right {
+	display: flex;
+	align-items: center;
+	flex: none;
+	justify-self: end;
+}
+
+.tribe-tickets__action-dashboard__action-wrapper {
+	flex: none;
+	margin-right: 25px;
+
+	&:last-child {
+		margin-right: 0;
+	}
+}
+
+.tribe-tickets__action-dashboard__cancel-button,
+.tribe-tickets__action-dashboard__confirm-button {
+	flex: none;
+	font-family: 'Helvetica', 'sans-serif';
+	border: none;
+}
+
+.tribe-tickets__action-dashboard__cancel-button {
+	background-color: transparent;
+	padding: 0;
+	margin-right: 20px;
+
+	&:last-child {
+		margin-right: 0;
+	}
+}
+
+.tribe-tickets__action-dashboard__confirm-button {
+	background-color: #00a0d4;
+	color: #ffffff;
+	padding: 9px 21px;
+	font-size: 1rem;
+	font-weight: bold;
+	line-height: 1.25rem;
+}

--- a/plugins/tickets/src/modules/elements/action-dashboard/style.pcss
+++ b/plugins/tickets/src/modules/elements/action-dashboard/style.pcss
@@ -54,4 +54,20 @@
 	font-size: 1rem;
 	font-weight: bold;
 	line-height: 1.25rem;
+	transition: background-color 0.2s ease;
+
+	&:hover,
+	&:focus {
+		background-color: #007bb4
+	}
+
+	&[disabled] {
+
+		&,
+		&:hover,
+		&:focus {
+			background-color: #f3f4f5;
+			color: #8d949b;
+		}
+	}
 }

--- a/plugins/tickets/src/modules/elements/button/element.js
+++ b/plugins/tickets/src/modules/elements/button/element.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const Button = ( {
+	className,
+	isDisabled,
+	label,
+	onClick,
+	type,
+} ) => (
+	<button
+		className={ classnames( 'tribe-tickets__button', className ) }
+		disabled={ isDisabled }
+		type={ type }
+		onClick={ onClick }
+	>
+		{ label }
+	</button>
+);
+
+Button.defaultProps = {
+	type: 'button',
+};
+
+Button.propTypes = {
+	className: PropTypes.string,
+	isDisabled: PropTypes.bool,
+	label: PropTypes.node,
+	onClick: PropTypes.func,
+	type: PropTypes.string,
+};
+
+export default Button;

--- a/plugins/tickets/src/modules/elements/index.js
+++ b/plugins/tickets/src/modules/elements/index.js
@@ -1,1 +1,2 @@
+export { default as ActionDashboard } from './action-dashboard/element';
 export { default as Button } from './button/element';

--- a/plugins/tickets/src/modules/elements/index.js
+++ b/plugins/tickets/src/modules/elements/index.js
@@ -1,0 +1,1 @@
+export { default as Button } from './button/element';


### PR DESCRIPTION
Still a WIP, but almost there. A couple notes here:

- The button component could potentially move to the common elements.
- I was following similar classname structure that @nealfennimore was using for events pro, but could be changed to something else if we're all in agreement.

For ticket: https://central.tri.be/issues/112919