### PR TITLE
Accept a `[200, 300)` response codes on request

### DIFF
--- a/plugins/common/src/modules/store/middlewares/request/__tests__/wp-request.test.js
+++ b/plugins/common/src/modules/store/middlewares/request/__tests__/wp-request.test.js
@@ -99,6 +99,41 @@ describe( '[STORE] - wp-request middleware', () => {
 		expect( meta.actions.success ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'execute success actions on 201 response code - creation code', async () => {
+		const { invoke } = create();
+
+		const body = {
+			id: 201,
+			date: '2018-05-26T23:07:05',
+			meta: {
+				title: 'Creating a post....'
+			},
+		};
+
+		const headers = new Headers();
+
+		global.fetch = jest.fn().mockImplementation( () =>
+			Promise.resolve( {
+				ok: true,
+				status: 201,
+				json: () => body,
+				headers,
+			} ),
+		);
+
+		await invoke( actions.wpRequest( { ...meta, path: 'tribe_organizer/1217' } ) );
+
+		expect.assertions( 8 );
+		expect( meta.actions.none ).not.toHaveBeenCalled();
+		expect( meta.actions.error ).not.toHaveBeenCalled();
+		expect( meta.actions.start ).toHaveBeenCalledWith( 'wp/v2/tribe_organizer/1217', {} );
+		expect( meta.actions.start ).toHaveBeenCalled();
+		expect( meta.actions.start ).toHaveBeenCalledTimes( 1 );
+		expect( meta.actions.success ).toHaveBeenCalled();
+		expect( meta.actions.success ).toHaveBeenCalledWith( { body, headers } );
+		expect( meta.actions.success ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'Should reject on 404 status code', async () => {
 		const { invoke } = create();
 

--- a/plugins/common/src/modules/store/middlewares/request/wp-request.js
+++ b/plugins/common/src/modules/store/middlewares/request/wp-request.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop, get } from 'lodash';
+import { noop, get, inRange } from 'lodash';
 import 'whatwg-fetch';
 
 /**
@@ -24,7 +24,7 @@ export default () => ( next ) => async ( action ) => {
 
 	next( action );
 
-	const rest = get( config(), 'rest', {} )
+	const rest = get( config(), 'rest', {} );
 	const { url = '', nonce = '' } = rest;
 	const namespaces = rest.namespaces || {};
 	const core = namespaces.core || 'wp/v2';
@@ -48,13 +48,13 @@ export default () => ( next ) => async ( action ) => {
 	actions.start( endpoint, params );
 
 	const headers = {
+		'Accept': 'application/json',
 		'Content-Type': 'application/json',
 		...get( params, 'headers', {} ),
 		'X-WP-Nonce': nonce,
 	};
 
 	try {
-
 		const response = await fetch( endpoint, {
 			...params,
 			credentials: 'include',
@@ -62,7 +62,7 @@ export default () => ( next ) => async ( action ) => {
 		} );
 
 		const { status } = response;
-		if ( status !== 200 ) {
+		if ( ! inRange( status, 200, 300 ) ) {
 			throw response;
 		}
 		const body = await response.json();

--- a/plugins/common/src/modules/store/middlewares/request/wp-request.js
+++ b/plugins/common/src/modules/store/middlewares/request/wp-request.js
@@ -62,6 +62,7 @@ export default () => ( next ) => async ( action ) => {
 		} );
 
 		const { status } = response;
+		// inRange includes 200 but excludes 300 from the range so it's from 200 up to 299
 		if ( ! inRange( status, 200, 300 ) ) {
 			throw response;
 		}

--- a/plugins/events/src/modules/data/forms/__tests__/__snapshots__/actions.test.js.snap
+++ b/plugins/events/src/modules/data/forms/__tests__/__snapshots__/actions.test.js.snap
@@ -106,28 +106,6 @@ Array [
 
 exports[`[STORE] - form thunk actions Maybe remove entry action without details 1`] = `Array []`;
 
-exports[`[STORE] - form thunk actions Seend the form when editing 1`] = `
-Array [
-  Object {
-    "meta": Object {
-      "actions": Object {
-        "error": [Function],
-        "start": [Function],
-        "success": [Function],
-      },
-      "params": Object {
-        "data": Object {
-          "ititle": "Tribe",
-        },
-        "method": "PUT",
-      },
-      "path": "tribe_venue/21",
-    },
-    "type": "@@MT/COMMON/WP_REQUEST",
-  },
-]
-`;
-
 exports[`[STORE] - form thunk actions Send the form action when creating 1`] = `
 Array [
   Object {
@@ -138,12 +116,30 @@ Array [
         "success": [Function],
       },
       "params": Object {
-        "data": Object {
-          "ititle": "Modern Tribe",
-        },
+        "body": "{\\"title\\":\\"Modern Tribe\\"}",
         "method": "POST",
       },
       "path": "tribe_organizer",
+    },
+    "type": "@@MT/COMMON/WP_REQUEST",
+  },
+]
+`;
+
+exports[`[STORE] - form thunk actions Send the form when editing 1`] = `
+Array [
+  Object {
+    "meta": Object {
+      "actions": Object {
+        "error": [Function],
+        "start": [Function],
+        "success": [Function],
+      },
+      "params": Object {
+        "body": "{\\"title\\":\\"Tribe\\"}",
+        "method": "PUT",
+      },
+      "path": "tribe_venue/21",
     },
     "type": "@@MT/COMMON/WP_REQUEST",
   },

--- a/plugins/events/src/modules/data/forms/__tests__/actions.test.js
+++ b/plugins/events/src/modules/data/forms/__tests__/actions.test.js
@@ -75,12 +75,12 @@ describe( '[STORE] - form thunk actions', () => {
 	afterEach( () => store.clearActions() );
 
 	test( 'Send the form action when creating', () => {
-		store.dispatch( actions.sendForm( 20, { ititle: 'Modern Tribe' } ) );
+		store.dispatch( actions.sendForm( 20, { title: 'Modern Tribe' } ) );
 		expect( store.getActions() ).toMatchSnapshot();
 	} );
 
-	test( 'Seend the form when editing', () => {
-		store.dispatch( actions.sendForm( 21, { ititle: 'Tribe' } ) );
+	test( 'Send the form when editing', () => {
+		store.dispatch( actions.sendForm( 21, { title: 'Tribe' } ) );
 		expect( store.getActions() ).toMatchSnapshot();
 	} );
 

--- a/plugins/events/src/modules/data/forms/actions.js
+++ b/plugins/events/src/modules/data/forms/actions.js
@@ -91,7 +91,7 @@ export const sendForm = ( id, fields = {}, completed ) => ( dispatch, getState )
 		path,
 		params: {
 			method: create ? 'POST' : 'PUT',
-			data: fields,
+			body: JSON.stringify( fields ),
 		},
 		actions: {
 			start: () => dispatch( setSaving( id, true ) ),

--- a/plugins/events/src/modules/elements/organizer-form/element.js
+++ b/plugins/events/src/modules/elements/organizer-form/element.js
@@ -82,7 +82,7 @@ class OrganizerForm extends Component {
 		const request = wp.apiRequest( {
 			path: `/wp/v2/${ basePath }`,
 			method: 'POST',
-			data: toSend,
+			body: JSON.stringify( toSend ),
 		} );
 
 		// Set the organizer state

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 #### 0.2.8-alpha - 2018-08-30
 
 * Feature - Add Tickets inside of the `plugins/` directory 
+* Fix - Accept responses between `200` and `299` HTTP codes as valid responses
 
 #### 0.2.7-alpha - 2018-08-30
 


### PR DESCRIPTION
Make sure respones that has other response code that `200`, like `201`
creation code are consider as valid ones.

Ticket: https://central.tri.be/issues/112207