### PR TITLE
Do a shallow comparision between elements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -138,6 +138,7 @@
     "afterEach": true,
     "it": true,
     "tribe_blocks_editor": true,
-    "mount": true
+    "mount": true,
+    "shallow": true,
   }
 }

--- a/plugins/common/src/modules/hoc/__tests__/__snapshots__/with-save-data.test.js.snap
+++ b/plugins/common/src/modules/hoc/__tests__/__snapshots__/with-save-data.test.js.snap
@@ -5,6 +5,7 @@ exports[`HOC - With Details Should render a component 1`] = `
   attributes={
     Object {
       "description": "",
+      "organizers": Array [],
       "title": "Modern Tribe",
     }
   }
@@ -13,6 +14,7 @@ exports[`HOC - With Details Should render a component 1`] = `
   name="tribe/event"
   onBlockCreated={[Function]}
   onBlockRemoved={[Function]}
+  organizers={Array []}
   setAttributes={[MockFunction]}
   setInitialState={
     [MockFunction] {
@@ -21,6 +23,7 @@ exports[`HOC - With Details Should render a component 1`] = `
           Object {
             "attributes": Object {
               "description": "",
+              "organizers": Array [],
               "title": "Modern Tribe",
             },
             "description": "The Next Generation of Digital Agency",
@@ -29,6 +32,7 @@ exports[`HOC - With Details Should render a component 1`] = `
             "name": "tribe/event",
             "onBlockCreated": [Function],
             "onBlockRemoved": [Function],
+            "organizers": Array [],
             "setAttributes": [MockFunction],
             "setInitialState": [MockFunction] {
               "calls": [Circular],

--- a/plugins/common/src/modules/hoc/__tests__/with-save-data.test.js
+++ b/plugins/common/src/modules/hoc/__tests__/with-save-data.test.js
@@ -98,6 +98,7 @@ describe( 'HOC - With Details', () => {
 			},
 		} );
 		expect( wrapperInstance.calculateDiff() ).toEqual( { organizers: [ 2, 3 ] } );
+		wrapperInstance.unregisterBlock();
 	} );
 
 	it( 'Should calculate the diff', () => {

--- a/plugins/common/src/modules/hoc/__tests__/with-save-data.test.js
+++ b/plugins/common/src/modules/hoc/__tests__/with-save-data.test.js
@@ -16,9 +16,11 @@ const props = {
 	setAttributes: jest.fn(),
 	title: 'Modern Tribe!',
 	description: 'The Next Generation of Digital Agency',
+	organizers: [],
 	attributes: {
 		title: 'Modern Tribe',
 		description: '',
+		organizers: [],
 	},
 };
 
@@ -61,6 +63,41 @@ describe( 'HOC - With Details', () => {
 	it( 'Should generate the keys', () => {
 		const HOC = component.getInstance();
 		expect( HOC.keys ).toEqual( Object.keys( props.attributes ) );
+	} );
+
+	it( 'Simulate componentDidUpdate call', () => {
+		const wrapper = shallow( <Wrapper { ...props } /> );
+		const wrapperInstance = wrapper.instance();
+		expect( wrapperInstance.calculateDiff() ).toEqual( {
+			description: 'The Next Generation of Digital Agency',
+			title: 'Modern Tribe!',
+		} );
+		wrapper.setProps( {
+			attributes: {
+				title: 'Modern Tribe!',
+				description: 'The Next Generation of Digital Agency',
+				organizers: [],
+			}
+		} );
+		expect( wrapperInstance.calculateDiff() ).toEqual( {} );
+		wrapper.setProps( {
+			organizers: [ 3 ],
+			attributes: {
+				title: 'Modern Tribe!',
+				description: 'The Next Generation of Digital Agency',
+				organizers: [ 3 ],
+			},
+		} );
+		expect( wrapperInstance.calculateDiff() ).toEqual( {} );
+		wrapper.setProps( {
+			organizers: [ 2, 3 ],
+			attributes: {
+				title: 'Modern Tribe!',
+				description: 'The Next Generation of Digital Agency',
+				organizers: [ 3, 2 ],
+			},
+		} );
+		expect( wrapperInstance.calculateDiff() ).toEqual( { organizers: [ 2, 3 ] } );
 	} );
 
 	it( 'Should calculate the diff', () => {

--- a/plugins/common/src/modules/hoc/with-save-data.js
+++ b/plugins/common/src/modules/hoc/with-save-data.js
@@ -90,6 +90,8 @@ export default ( selectedAttributes = null ) => ( WrappedComponent ) => {
 						return key in attributes ? attributes[ key ] : defaultValue;
 					},
 				} );
+
+				this.saving = this.calculateDiff();
 			}
 
 			componentWillUnmount() {
@@ -121,16 +123,18 @@ export default ( selectedAttributes = null ) => ( WrappedComponent ) => {
 				}
 
 				this.saving = diff;
+
 				if ( isEmpty( diff ) ) {
 					return;
 				}
+
 				this.props.setAttributes( diff );
 			}
 
 			calculateDiff() {
 				const attributes = this.attrs;
 				return this.keys.reduce( ( diff, key ) => {
-					if ( key in this.props && attributes[ key ] !== this.props[ key ] ) {
+					if ( key in this.props && ! isShallowEqual( attributes[ key ], this.props[ key ] ) ) {
 						diff[ key ] = this.props[ key ];
 					}
 					return diff;

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 * Feature - Add Tickets inside of the `plugins/` directory 
 * Fix - Accept responses between `200` and `299` HTTP codes as valid responses
+* Fix - Prevent to set attributes when arrays have the same content
 
 #### 0.2.7-alpha - 2018-08-30
 


### PR DESCRIPTION
For elements like array or objects when values are the same as they are
objects the references to those objects are different so doing a strict
comparission returns false eve if the values of each is the same

Ticket: https://central.tri.be/issues/112578