### PR TITLE
Allow for saving on new event creation

### DIFF
--- a/plugins/common/src/modules/hoc/with-save-data.js
+++ b/plugins/common/src/modules/hoc/with-save-data.js
@@ -90,8 +90,6 @@ export default ( selectedAttributes = null ) => ( WrappedComponent ) => {
 						return key in attributes ? attributes[ key ] : defaultValue;
 					},
 				} );
-
-				this.saving = this.calculateDiff();
 			}
 
 			componentWillUnmount() {

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 ### Changelog
 
+#### 0.2.9-alpha - 2018-09-14
+
+* Fix - Prevent empty diff on new event creation
+
 #### 0.2.8-alpha - 2018-09-14
 
 * Feature - Add Tickets inside of the `plugins/` directory

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 ### Changelog
 
-#### 0.2.9-alpha - 2018-09-14
+#### 0.2.9-alpha - TBD
 
 * Fix - Prevent empty diff on new event creation
 


### PR DESCRIPTION
Make sure when the event is first created the diff is not generated
until the save has been saved.