### PR TITLE
Prevent generation of empty classic blocks

### DIFF
--- a/plugins/events/src/Tribe/Editor.php
+++ b/plugins/events/src/Tribe/Editor.php
@@ -106,14 +106,17 @@ extends Tribe__Gutenberg__Common__Editor {
 	 * @return bool
 	 */
 	public function update_post_content_to_blocks( $post ) {
-		$post = get_post( $post );
-		$blocks = $this->get_classic_template();
+		$post    = get_post( $post );
+		$blocks  = $this->get_classic_template();
 		$content = array();
 
 		foreach ( $blocks as $key => $block_param ) {
 			$slug = reset( $block_param );
 
 			if ( 'core/paragraph' === $slug ) {
+				if ( '' === $post->post_content ) {
+					continue;
+				}
 				$content[] = '<!-- wp:freeform -->';
 				$content[] = $post->post_content;
 				$content[] = '<!-- /wp:freeform -->';

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 #### 0.2.9-alpha - TBD
 
- * Fix - Prevent generation of empty classic blocks when merging events to gutenberg with empty content
+ * Fix - Prevent generation of empty classic blocks when migrating events to gutenberg with empty content
 
 #### 0.2.8-alpha - 2018-09-14
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 ### Changelog
 
+#### 0.2.9-alpha - TBD
+
+ * Fix - Prevent generation of empty classic blocks when merging events to gutenberg with empty content
+
 #### 0.2.8-alpha - 2018-09-14
 
 * Feature - Add Tickets inside of the `plugins/` directory


### PR DESCRIPTION
🎫 https://central.tri.be/issues/113157

The ticket instructions weren't so specific. I assumed this happened when migrating events with empty description (it was actually happening).

Not sure if we should be using the `paragraph` block instead of `freeform`. I assume this is just in case they have like a rich edited description with pictures and stuff, right?