### PR TITLE
RSVP: Use the `post_id` from the main template

### DIFF
--- a/plugins/tickets/src/Tribe/Blocks/Rsvp.php
+++ b/plugins/tickets/src/Tribe/Blocks/Rsvp.php
@@ -53,7 +53,7 @@ extends Tribe__Gutenberg__Common__Blocks__Abstract {
 	 * @return string
 	 */
 	public function render( $attributes = array() ) {
-		$post_id            = tribe( 'gutenberg.tickets.template' )->get( 'post_id' );
+		$post_id            = tribe( 'gutenberg.events.template' )->get( 'post_id' );
 		$args['attributes'] = $this->attributes( $attributes );
 		$args['tickets']    = $this->get_tickets( $post_id );
 

--- a/plugins/tickets/src/Tribe/Blocks/Rsvp.php
+++ b/plugins/tickets/src/Tribe/Blocks/Rsvp.php
@@ -53,6 +53,7 @@ extends Tribe__Gutenberg__Common__Blocks__Abstract {
 	 * @return string
 	 */
 	public function render( $attributes = array() ) {
+		// @TODO: Be sure we get the post ID from tickets so it can run without TEC
 		$post_id            = tribe( 'gutenberg.events.template' )->get( 'post_id' );
 		$args['attributes'] = $this->attributes( $attributes );
 		$args['tickets']    = $this->get_tickets( $post_id );


### PR DESCRIPTION
🎫 https://central.tri.be/issues/112191

Been checking the views for RSVP on the new architecture. The only problem I found was that the post_id wasn't making it to the guten tickets template class. I think this will be probably resolved later once we make pages and posts compatible with tickets and guten as standalone.

By now, I think this will make us have the functionality in events.