### PR TITLE
Removes `_edd_button_behavior` key from REST API

### DIFF
--- a/plugins/tickets/src/Tribe/Meta.php
+++ b/plugins/tickets/src/Tribe/Meta.php
@@ -125,6 +125,26 @@ class Tribe__Gutenberg__Tickets__Meta {
 	}
 
 	/**
+	 * Removes `_edd_button_behavior` key from the REST API where tickets blocks is used
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args
+	 * @param string $defaults
+	 * @param string $object_type
+	 * @param string $meta_key
+	 * @return array
+	 */
+	public function register_meta_args( $args = array(), $defaults = '', $object_type = '', $meta_key = '' ) {
+		error_log( $meta_key );
+		if ( $meta_key === '_edd_button_behavior' ) {
+			$args['show_in_rest'] = false;
+		}
+		return $args;
+	}
+
+
+	/**
 	 * Default definition for an attribute of type text
 	 *
 	 * @since TBD

--- a/plugins/tickets/src/Tribe/Meta.php
+++ b/plugins/tickets/src/Tribe/Meta.php
@@ -136,7 +136,6 @@ class Tribe__Gutenberg__Tickets__Meta {
 	 * @return array
 	 */
 	public function register_meta_args( $args = array(), $defaults = '', $object_type = '', $meta_key = '' ) {
-		error_log( $meta_key );
 		if ( $meta_key === '_edd_button_behavior' ) {
 			$args['show_in_rest'] = false;
 		}

--- a/plugins/tickets/src/Tribe/Provider.php
+++ b/plugins/tickets/src/Tribe/Provider.php
@@ -66,6 +66,12 @@ class Tribe__Gutenberg__Tickets__Provider extends tad_DI52_ServiceProvider {
 
 		// Setup the Meta registration
 		add_action( 'init', tribe_callback( 'gutenberg.tickets.meta', 'register' ), 15 );
+		add_filter(
+			'register_meta_args',
+			tribe_callback( 'gutenberg.tickets.meta', 'register_meta_args' ),
+			10,
+			4
+		);
 
 		// Setup the Rest compatibility layer for WP
 		tribe( 'gutenberg.tickets.rest.compatibility' );


### PR DESCRIPTION
The attribute can't be set via the tickets API and is not used so
removing it from the Tickets pages allows to save the ticket.