### PR TITLE
Render "Not Going" button based on `meta` field

### DIFF
--- a/plugins/tickets/src/Tribe/Meta.php
+++ b/plugins/tickets/src/Tribe/Meta.php
@@ -72,7 +72,7 @@ class Tribe__Gutenberg__Tickets__Meta {
 		register_meta(
 			'post',
 			'_tribe_ticket_show_not_going',
-			$this->text()
+			$this->boolean()
 		);
 
 		// Global Stock

--- a/plugins/tickets/src/modules/blocks/rsvp/container.js
+++ b/plugins/tickets/src/modules/blocks/rsvp/container.js
@@ -42,19 +42,16 @@ const getIsInactive = ( state ) => {
 const setInitialState = ( dispatch, ownProps ) => () => {
 	const postId = select( 'core/editor' ).getCurrentPostId();
 	dispatch( thunks.getRSVP( postId ) );
-	if ( ownProps.attributes.headerImageId ) {
-		dispatch( thunks.getRSVPHeaderImage(
-			ownProps.attributes.headerImageId
-		) );
+	const { attributes = {} } = ownProps;
+	if ( attributes.headerImageId ) {
+		dispatch( thunks.getRSVPHeaderImage( attributes.headerImageId ) );
 	}
-	if ( ownProps.attributes.goingCount ) {
-		dispatch( actions.setRSVPGoingCount(
-			parseInt( ownProps.attributes.goingCount, 10 )
-		) );
+	if ( attributes.goingCount ) {
+		dispatch( actions.setRSVPGoingCount( parseInt( attributes.goingCount, 10 ) ) );
 	}
-	if ( ownProps.attributes.notGoingCount ) {
+	if ( attributes.notGoingCount ) {
 		dispatch( actions.setRSVPNotGoingCount(
-			parseInt( ownProps.attributes.notGoingCount, 10 )
+			parseInt( attributes.notGoingCount, 10 )
 		) );
 	}
 };

--- a/plugins/tickets/src/modules/data/blocks/rsvp/thunks.js
+++ b/plugins/tickets/src/modules/data/blocks/rsvp/thunks.js
@@ -50,7 +50,7 @@ const createOrUpdateRSVP = ( method ) => ( payload ) => ( dispatch ) => {
 			[ utils.KEY_TICKET_CAPACITY ]: capacity,
 			[ utils.KEY_TICKET_START_DATE ]: momentUtil.toDateTime( startMoment ),
 			[ utils.KEY_TICKET_END_DATE ]: momentUtil.toDateTime( endMoment ),
-			[ utils.KEY_TICKET_SHOW_NOT_GOING ]: notGoingResponses ? 'yes' : 'no',
+			[ utils.KEY_TICKET_SHOW_NOT_GOING ]: notGoingResponses,
 		},
 	};
 
@@ -133,7 +133,7 @@ export const getRSVP = ( postId, page = 1 ) => ( dispatch ) => {
 					const capacity = meta[ utils.KEY_TICKET_CAPACITY ] >= 0
 						? meta[ utils.KEY_TICKET_CAPACITY ]
 						: '';
-					const notGoingResponses = meta[ utils.KEY_TICKET_SHOW_NOT_GOING ] == 'yes';
+					const notGoingResponses = meta[ utils.KEY_TICKET_SHOW_NOT_GOING ];
 
 					dispatch( actions.createRSVP() );
 					dispatch( actions.setRSVPId( rsvp.id ) );

--- a/plugins/tickets/src/views/blocks/rsvp/status/not-going.php
+++ b/plugins/tickets/src/views/blocks/rsvp/status/not-going.php
@@ -5,6 +5,20 @@
  * @version 0.3.0-alpha
  *
  */
+
+/**
+ * @todo: Create a hook for the get_ticket method in order to set dynamic or custom properties into
+ * the instance variable so we can set a new one called $ticket->show_not_going.
+ *
+ * For now we need to access directly the value of the meta field in order to render this field.
+ */
+$show_not_going = tribe_is_truthy(
+	get_post_meta( $ticket->ID, '_tribe_ticket_show_not_going', true )
+);
+
+if ( ! $show_not_going ) {
+    return;
+}
 ?>
 <span>
 	<button class="tribe-block__rsvp__status-button tribe-block__rsvp__status-button--not-going">

--- a/plugins/tickets/src/views/blocks/rsvp/status/not-going.php
+++ b/plugins/tickets/src/views/blocks/rsvp/status/not-going.php
@@ -10,6 +10,9 @@
  * @todo: Create a hook for the get_ticket method in order to set dynamic or custom properties into
  * the instance variable so we can set a new one called $ticket->show_not_going.
  *
+ * Method is located on:
+ * - https://github.com/moderntribe/event-tickets/blob/9e77f61f191bbc86ee9ec9a0277ed7dde66ba0d8/src/Tribe/RSVP.php#L1130
+ *
  * For now we need to access directly the value of the meta field in order to render this field.
  */
 $show_not_going = tribe_is_truthy(

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,8 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 * Fix - Error when multi day toggle component was not functional 
 * Fix - Prevent reset of times when set for an event from time pickers
 * Fix - Make sure `meta` types matches before send into the request for `Tickets` block
-* Fix - Load Going an Not Going values on the RSVP form
+* Fix - Load Going an Not Going values on the RSVP block
+* Fix - Render "Not Going" `<button>` on RSVP block conditionally
 
 #### 0.3.0-alpha - 2018-10-05
 


### PR DESCRIPTION
Make sure the `<button>` or view that renders the not going action is conditionally rendered via the ticket meta field.

**Ticket** https://central.tri.be/issues/115795