### PR TITLE
Fix Venue selection on the Venue block

### DIFF
--- a/plugins/events/src/modules/data/blocks/venue/__tests__/__snapshots__/reducer.test.js.snap
+++ b/plugins/events/src/modules/data/blocks/venue/__tests__/__snapshots__/reducer.test.js.snap
@@ -44,7 +44,7 @@ exports[`[STORE] - Venue reducer Should set the venue 1`] = `
 Object {
   "showMap": true,
   "showMapLink": true,
-  "venue": undefined,
+  "venue": 99,
 }
 `;
 

--- a/plugins/events/src/modules/data/blocks/venue/reducer.js
+++ b/plugins/events/src/modules/data/blocks/venue/reducer.js
@@ -15,7 +15,7 @@ export default ( state = DEFAULT_STATE, action ) => {
 		case types.SET_VENUE:
 			return {
 				...state,
-				venue: state.venue,
+				venue: action.payload.venue,
 			};
 		case types.TOGGLE_VENUE_MAP:
 			return {

--- a/plugins/events/src/modules/data/blocks/venue/sagas.js
+++ b/plugins/events/src/modules/data/blocks/venue/sagas.js
@@ -12,9 +12,10 @@ import * as actions from './actions';
 
 export function* setInitialState( action ) {
 	const { get } = action.payload;
+	const venue = get( 'venue' ) ? get( 'venue' ) : DEFAULT_STATE.venue;
 
 	yield all( [
-		put( actions.setVenue( get( 'venue', DEFAULT_STATE.venue ) ) ),
+		put( actions.setVenue( venue ) ),
 		put( actions.setShowMap( get( 'showMap', DEFAULT_STATE.showMap ) ) ),
 		put( actions.setShowMapLink( get( 'showMapLink', DEFAULT_STATE.showMapLink ) ) ),
 	] );

--- a/plugins/events/src/modules/data/blocks/venue/utils.js
+++ b/plugins/events/src/modules/data/blocks/venue/utils.js
@@ -43,7 +43,7 @@ export function getVenueCountry( meta ) {
 
 	if ( '' === country ) {
 		const defaultCountry = editorDefaults().venueCountry;
-		country = defaultCountry !== undefined || array.length > 0 ? defaultCountry[1] : '';
+		country = defaultCountry !== undefined || defaultCountry.length > 0 ? defaultCountry[1] : '';
 	}
 	return country;
 }

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 * Fix - Make sure `meta` types matches before send into the request for `Tickets` block
 * Fix - Load Going an Not Going values on the RSVP block
 * Fix - Render "Not Going" `<button>` on RSVP block conditionally
+* Fix - Make sure that the event venue selection works
 
 #### 0.3.0-alpha - 2018-10-05
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/115807

The set venue was using state instead of the action payload value. And the initial state wasn't getting the default value (if defined) because get was returning zero (and not using the default). Also fixed a call to the length method over the array.