### PR TITLE
Remove price rendering from the date time block when coming from classic

### DIFF
--- a/plugins/events/src/modules/blocks/event-datetime/template.js
+++ b/plugins/events/src/modules/blocks/event-datetime/template.js
@@ -101,31 +101,6 @@ class EventDateTime extends Component {
 		document.removeEventListener( 'click', onClick );
 	}
 
-	renderPrice = () => {
-		const { cost, currencyPosition, currencySymbol, setCost } = this.props;
-
-		// Bail when not classic
-		if ( ! tribe_blocks_editor || ! tribe_blocks_editor.is_classic ) {
-			return null;
-		}
-
-		return (
-			<div
-				key="tribe-editor-event-cost"
-				className="tribe-editor__event-cost"
-			>
-				{ 'prefix' === currencyPosition && <span>{ currencySymbol }</span> }
-				<PlainText
-					className={ classNames( 'tribe-editor__event-cost__value', `tribe-editor-cost-symbol-position-${ currencyPosition }` ) }
-					value={ cost }
-					placeholder={ __( 'Enter price', 'events-gutenberg' ) }
-					onChange={ setCost }
-				/>
-				{ 'suffix' === currencyPosition && <span>{ currencySymbol }</span> }
-			</div>
-		);
-	}
-
 	renderStartDate = () => {
 		const { start, end } = this.props;
 		let startDate = toDate( toMoment( start ) );
@@ -240,7 +215,6 @@ class EventDateTime extends Component {
 		return (
 			<Fragment>
 				{ this.renderTimezone() }
-				{ this.renderPrice() }
 			</Fragment>
 		);
 	}

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 * Fix - Make sure `meta` types matches before send into the request for `Tickets` block
 * Fix - Load Going an Not Going values on the RSVP block
 * Fix - Render "Not Going" `<button>` on RSVP block conditionally
+* Tweak - Remove price rendering from the Date Time block when coming from the classic editor
 
 #### 0.3.0-alpha - 2018-10-05
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/112140

We kept displaying the price within the date-time block when it came from the classic editor.