### PR TITLE
Adjust vertical alignment of the price section for the classic event datetime block

### DIFF
--- a/plugins/events/src/modules/blocks/event-datetime/style.pcss
+++ b/plugins/events/src/modules/blocks/event-datetime/style.pcss
@@ -31,6 +31,7 @@
 	.tribe-editor__event-cost {
 		display: inline-block;
 		margin-left: 15px;
+		vertical-align: middle;
 
 		span {
 			display: inline-block;

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ Finally, run `npm run bootstrap` from the root to link the plugin up.
 
 ### Changelog
 
+#### 0.3.2-alpha - TBD
+
+* Fix - Adjust vertical alignment of the price section for the classic event date time block
+
 #### 0.3.1-alpha - 2018-10-12
 
 * Fix - Make sure Classic Editor migration treats correctly Events with Tickets


### PR DESCRIPTION
🎫 https://central.tri.be/issues/112140