### PR TITLE
Add styles for the input types on Edit Container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,31 @@
 				"@babel/types": "7.0.0-beta.44"
 			}
 		},
+		"@babel/helper-module-imports": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+					"integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.10",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+				}
+			}
+		},
 		"@babel/helper-split-export-declaration": {
 			"version": "7.0.0-beta.44",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
@@ -253,6 +278,62 @@
 			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
 			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
 			"dev": true
+		},
+		"@emotion/babel-utils": {
+			"version": "0.6.10",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
+			"integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
+			"requires": {
+				"@emotion/hash": "^0.6.6",
+				"@emotion/memoize": "^0.6.6",
+				"@emotion/serialize": "^0.9.1",
+				"convert-source-map": "^1.5.1",
+				"find-root": "^1.1.0",
+				"source-map": "^0.7.2"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+				}
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
+			"integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
+		},
+		"@emotion/memoize": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+			"integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+		},
+		"@emotion/serialize": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
+			"integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
+			"requires": {
+				"@emotion/hash": "^0.6.6",
+				"@emotion/memoize": "^0.6.6",
+				"@emotion/unitless": "^0.6.7",
+				"@emotion/utils": "^0.8.2"
+			}
+		},
+		"@emotion/stylis": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
+			"integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
+		},
+		"@emotion/unitless": {
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
+			"integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
+		},
+		"@emotion/utils": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
+			"integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
 		},
 		"@lerna/add": {
 			"version": "3.4.1",
@@ -2034,8 +2115,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.3.5",
@@ -2283,7 +2363,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -2876,6 +2955,25 @@
 				"babel-runtime": "^6.22.0"
 			}
 		},
+		"babel-plugin-emotion": {
+			"version": "9.2.11",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
+			"integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@emotion/babel-utils": "^0.6.4",
+				"@emotion/hash": "^0.6.2",
+				"@emotion/memoize": "^0.6.1",
+				"@emotion/stylis": "^0.7.0",
+				"babel-plugin-macros": "^2.0.0",
+				"babel-plugin-syntax-jsx": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"find-root": "^1.1.0",
+				"mkdirp": "^0.5.1",
+				"source-map": "^0.5.7",
+				"touch": "^2.0.1"
+			}
+		},
 		"babel-plugin-import-glob": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-import-glob/-/babel-plugin-import-glob-2.0.0.tgz",
@@ -2915,6 +3013,25 @@
 				"lodash": "^4.17.2"
 			}
 		},
+		"babel-plugin-macros": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
+			"integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+			"requires": {
+				"cosmiconfig": "^5.0.5",
+				"resolve": "^1.8.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
+		},
 		"babel-plugin-react-svg": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-react-svg/-/babel-plugin-react-svg-2.1.0.tgz",
@@ -2948,8 +3065,7 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -4673,8 +4789,7 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-			"dev": true
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 		},
 		"cookie": {
 			"version": "0.3.1",
@@ -4723,7 +4838,6 @@
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
 			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
-			"dev": true,
 			"requires": {
 				"is-directory": "^0.3.1",
 				"js-yaml": "^3.9.0",
@@ -4734,7 +4848,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.3.1",
 						"json-parse-better-errors": "^1.0.1"
@@ -4781,6 +4894,20 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
+			}
+		},
+		"create-emotion": {
+			"version": "9.2.12",
+			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
+			"integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
+			"requires": {
+				"@emotion/hash": "^0.6.2",
+				"@emotion/memoize": "^0.6.1",
+				"@emotion/stylis": "^0.7.0",
+				"@emotion/unitless": "^0.6.2",
+				"csstype": "^2.5.2",
+				"stylis": "^3.5.0",
+				"stylis-rule-sheet": "^0.0.10"
 			}
 		},
 		"create-hash": {
@@ -5030,6 +5157,11 @@
 			"requires": {
 				"cssom": "0.3.x"
 			}
+		},
+		"csstype": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
+			"integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -5389,6 +5521,11 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"dom-helpers": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+			"integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+		},
 		"dom-serializer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
@@ -5530,6 +5667,15 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
 		},
+		"emotion": {
+			"version": "9.2.12",
+			"resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
+			"integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
+			"requires": {
+				"babel-plugin-emotion": "^9.2.11",
+				"create-emotion": "^9.2.12"
+			}
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5647,7 +5793,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -6067,8 +6212,7 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
 			"version": "1.0.1",
@@ -6097,8 +6241,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -6686,6 +6829,11 @@
 				"make-dir": "^1.0.0",
 				"pkg-dir": "^2.0.0"
 			}
+		},
+		"find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
 		},
 		"find-up": {
 			"version": "2.1.0",
@@ -8409,8 +8557,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -8494,8 +8641,7 @@
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -9643,7 +9789,6 @@
 			"version": "3.12.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -9699,8 +9844,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -10239,6 +10383,11 @@
 			"resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
 			"integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
 		},
+		"memoize-one": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
+			"integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
+		},
 		"memory-fs": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -10525,8 +10674,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -10608,7 +10756,6 @@
 			"version": "0.5.1",
 			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -11770,8 +11917,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -11806,8 +11952,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -14128,7 +14273,6 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
-			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
@@ -14305,6 +14449,11 @@
 			"integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
 			"dev": true
 		},
+		"react-lifecycles-compat": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+		},
 		"react-places-autocomplete": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/react-places-autocomplete/-/react-places-autocomplete-6.1.3.tgz",
@@ -14342,6 +14491,20 @@
 			"integrity": "sha512-d3VtXVdyRT82cjvTCcapWBMXkXumbUTZmgMNJTtNdkiDAa4Uc+TAL6qHWpxbUodAfLA3to818PgJH+SNY3ABiw==",
 			"requires": {
 				"prop-types": "^15.6.1"
+			}
+		},
+		"react-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/react-select/-/react-select-2.1.0.tgz",
+			"integrity": "sha512-3SdRAKX64hNzDF/DT1J1Ei3fIoQlLMkMJuB3yOY6oOYwl2A9SFJMsqXLgsveiu7UGrdo+4lyZi3mSqvw8qeGMA==",
+			"requires": {
+				"classnames": "^2.2.5",
+				"emotion": "^9.1.2",
+				"memoize-one": "^4.0.0",
+				"prop-types": "^15.6.0",
+				"raf": "^3.4.0",
+				"react-input-autosize": "^2.2.1",
+				"react-transition-group": "^2.2.1"
 			}
 		},
 		"react-svg-core": {
@@ -14389,6 +14552,17 @@
 				"react": ">=0.13.0",
 				"react-dom": ">=0.13.0",
 				"react-scroll-box": "~0.2.0"
+			}
+		},
+		"react-transition-group": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
+			"integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+			"requires": {
+				"dom-helpers": "^3.3.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2",
+				"react-lifecycles-compat": "^3.0.4"
 			}
 		},
 		"read": {
@@ -15539,8 +15713,7 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
@@ -15632,8 +15805,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.14.2",
@@ -15898,6 +16070,16 @@
 					}
 				}
 			}
+		},
+		"stylis": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
+			"integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
+		},
+		"stylis-rule-sheet": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
 		},
 		"supports-color": {
 			"version": "5.4.0",
@@ -16176,6 +16358,24 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
+			}
+		},
+		"touch": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
+			"integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
+			"requires": {
+				"nopt": "~1.0.10"
+			},
+			"dependencies": {
+				"nopt": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+					"requires": {
+						"abbrev": "1"
+					}
+				}
 			}
 		},
 		"tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"react-places-autocomplete": "^6.1.2",
 		"react-redux": "^5.0.7",
 		"react-scroll-to": "^1.2.2",
+		"react-select": "^2.1.0",
 		"react-text-input": "^0.0.8",
 		"redux": "^4.0.0",
 		"redux-saga": "^0.16.1",

--- a/plugins/common/src/modules/elements/index.js
+++ b/plugins/common/src/modules/elements/index.js
@@ -13,3 +13,4 @@ export { default as Tooltip } from './tooltip/element';
 export { default as Placeholder } from './placeholder/element';
 export { default as Heading } from './heading/element';
 export { default as Paragraph } from './paragraph/element';
+export { default as Select } from './select/element';

--- a/plugins/common/src/modules/elements/select/__tests__/__snapshots__/element.test.js.snap
+++ b/plugins/common/src/modules/elements/select/__tests__/__snapshots__/element.test.js.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select element Should render the component 1`] = `
+<div
+  className="css-10nd86i tribe-editor__select"
+  onKeyDown={[Function]}
+>
+  <div
+    className="css-vj8t7z tribe-editor__select__control"
+    onMouseDown={[Function]}
+    onTouchEnd={[Function]}
+  >
+    <div
+      className="css-1hwfws3 tribe-editor__select__value-container"
+    >
+      <div
+        className="css-1492t68 tribe-editor__select__placeholder"
+      >
+        Select...
+      </div>
+      <div
+        className="css-1g6gooi"
+      >
+        <div
+          className="tribe-editor__select__input"
+          style={
+            Object {
+              "display": "inline-block",
+            }
+          }
+        >
+          <input
+            aria-autocomplete="list"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            disabled={false}
+            id="react-select-2-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            spellCheck="false"
+            style={
+              Object {
+                "background": 0,
+                "border": 0,
+                "boxSizing": "content-box",
+                "color": "inherit",
+                "fontSize": "inherit",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "1px",
+              }
+            }
+            tabIndex="0"
+            theme={
+              Object {
+                "borderRadius": 4,
+                "colors": Object {
+                  "danger": "#DE350B",
+                  "dangerLight": "#FFBDAD",
+                  "neutral0": "hsl(0, 0%, 100%)",
+                  "neutral10": "hsl(0, 0%, 90%)",
+                  "neutral20": "hsl(0, 0%, 80%)",
+                  "neutral30": "hsl(0, 0%, 70%)",
+                  "neutral40": "hsl(0, 0%, 60%)",
+                  "neutral5": "hsl(0, 0%, 95%)",
+                  "neutral50": "hsl(0, 0%, 50%)",
+                  "neutral60": "hsl(0, 0%, 40%)",
+                  "neutral70": "hsl(0, 0%, 30%)",
+                  "neutral80": "hsl(0, 0%, 20%)",
+                  "neutral90": "hsl(0, 0%, 10%)",
+                  "primary": "#2684FF",
+                  "primary25": "#DEEBFF",
+                  "primary50": "#B2D4FF",
+                  "primary75": "#4C9AFF",
+                },
+                "spacing": Object {
+                  "baseUnit": 4,
+                  "controlHeight": 38,
+                  "menuGutter": 8,
+                },
+              }
+            }
+            type="text"
+            value=""
+          />
+          <div
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "scroll",
+                "position": "absolute",
+                "top": 0,
+                "visibility": "hidden",
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="css-1wy0on6 tribe-editor__select__indicators"
+    >
+      <div
+        aria-hidden="true"
+        className="css-1ep9fjw tribe-editor__select__indicator tribe-editor__select__dropdown-indicator"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <span
+          className="tribe-editor__select__dropdown-indicator"
+        >
+          arrow-down
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select element Should render the component with class 1`] = `
+<div
+  className="css-10nd86i tribe-editor__select test-class"
+  onKeyDown={[Function]}
+>
+  <div
+    className="css-vj8t7z tribe-editor__select__control"
+    onMouseDown={[Function]}
+    onTouchEnd={[Function]}
+  >
+    <div
+      className="css-1hwfws3 tribe-editor__select__value-container"
+    >
+      <div
+        className="css-1492t68 tribe-editor__select__placeholder"
+      >
+        Select...
+      </div>
+      <div
+        className="css-1g6gooi"
+      >
+        <div
+          className="tribe-editor__select__input"
+          style={
+            Object {
+              "display": "inline-block",
+            }
+          }
+        >
+          <input
+            aria-autocomplete="list"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            disabled={false}
+            id="react-select-3-input"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            spellCheck="false"
+            style={
+              Object {
+                "background": 0,
+                "border": 0,
+                "boxSizing": "content-box",
+                "color": "inherit",
+                "fontSize": "inherit",
+                "opacity": 1,
+                "outline": 0,
+                "padding": 0,
+                "width": "1px",
+              }
+            }
+            tabIndex="0"
+            theme={
+              Object {
+                "borderRadius": 4,
+                "colors": Object {
+                  "danger": "#DE350B",
+                  "dangerLight": "#FFBDAD",
+                  "neutral0": "hsl(0, 0%, 100%)",
+                  "neutral10": "hsl(0, 0%, 90%)",
+                  "neutral20": "hsl(0, 0%, 80%)",
+                  "neutral30": "hsl(0, 0%, 70%)",
+                  "neutral40": "hsl(0, 0%, 60%)",
+                  "neutral5": "hsl(0, 0%, 95%)",
+                  "neutral50": "hsl(0, 0%, 50%)",
+                  "neutral60": "hsl(0, 0%, 40%)",
+                  "neutral70": "hsl(0, 0%, 30%)",
+                  "neutral80": "hsl(0, 0%, 20%)",
+                  "neutral90": "hsl(0, 0%, 10%)",
+                  "primary": "#2684FF",
+                  "primary25": "#DEEBFF",
+                  "primary50": "#B2D4FF",
+                  "primary75": "#4C9AFF",
+                },
+                "spacing": Object {
+                  "baseUnit": 4,
+                  "controlHeight": 38,
+                  "menuGutter": 8,
+                },
+              }
+            }
+            type="text"
+            value=""
+          />
+          <div
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "scroll",
+                "position": "absolute",
+                "top": 0,
+                "visibility": "hidden",
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="css-1wy0on6 tribe-editor__select__indicators"
+    >
+      <div
+        aria-hidden="true"
+        className="css-1ep9fjw tribe-editor__select__indicator tribe-editor__select__dropdown-indicator"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <span
+          className="tribe-editor__select__dropdown-indicator"
+        >
+          arrow-down
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select element Should render the component with extra props 1`] = `
+<div
+  className="css-10nd86i tribe-editor__select"
+  onKeyDown={[Function]}
+>
+  <div
+    className="css-vj8t7z tribe-editor__select__control"
+    onMouseDown={[Function]}
+    onTouchEnd={[Function]}
+  >
+    <div
+      className="css-1hwfws3 tribe-editor__select__value-container"
+    >
+      <div
+        className="css-1492t68 tribe-editor__select__placeholder"
+      >
+        Select...
+      </div>
+      <input
+        className="css-14uuagi"
+        id="react-select-4-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={true}
+        tabIndex="0"
+        value=""
+      />
+    </div>
+    <div
+      className="css-1wy0on6 tribe-editor__select__indicators"
+    >
+      <div
+        aria-hidden="true"
+        className="css-1ep9fjw tribe-editor__select__indicator tribe-editor__select__dropdown-indicator"
+        onMouseDown={[Function]}
+        onTouchEnd={[Function]}
+      >
+        <span
+          className="tribe-editor__select__dropdown-indicator"
+        >
+          arrow-down
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/plugins/common/src/modules/elements/select/__tests__/element.test.js
+++ b/plugins/common/src/modules/elements/select/__tests__/element.test.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Select from '../element.js';
+
+const options = [
+	{ label: 'Test 1', value: 'test-1' },
+	{ label: 'Test 2', value: 'test-2' },
+];
+
+describe( 'Select element', () => {
+	it( 'Should render the component', () => {
+		const component = renderer.create( <Select options={ options } /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	it( 'Should render the component with class', () => {
+		const component = renderer.create( <Select options={ options } className="test-class" /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	it( 'Should render the component with extra props', () => {
+		const component = renderer.create( <Select options={ options } isSearchable={ false } /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+} );

--- a/plugins/common/src/modules/elements/select/element.js
+++ b/plugins/common/src/modules/elements/select/element.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import ReactSelect, { components } from 'react-select';
+import { Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.pcss';
+
+const DropdownIndicator = ( props ) => (
+	components.DropdownIndicator && (
+		<components.DropdownIndicator { ...props }>
+			<Dashicon
+				className="tribe-editor__select__dropdown-indicator"
+				icon={ 'arrow-down' }
+			/>
+		</components.DropdownIndicator>
+	)
+);
+
+const IndicatorSeparator = () => null;
+
+const Select = ( { className, ...rest } ) => (
+	<ReactSelect
+		className={ classNames( 'tribe-editor__select', className ) }
+		classNamePrefix="tribe-editor__select"
+		components={ { DropdownIndicator, IndicatorSeparator } }
+		{ ...rest }
+	/>
+);
+
+Select.propTypes = {
+	className: PropTypes.string,
+};
+
+export default Select;

--- a/plugins/common/src/modules/elements/select/style.pcss
+++ b/plugins/common/src/modules/elements/select/style.pcss
@@ -1,0 +1,61 @@
+.tribe-editor__select {
+
+	.tribe-editor__select__control {
+		height: 46px;
+		border: 1px solid #E1E3E6;
+		border-radius: 3px;
+		background-color: #FFFFFF;
+
+		&:hover {
+			border: 1px solid #E1E3E6;
+		}
+
+		&--is-focused {
+			box-shadow: none;
+		}
+	}
+
+	.tribe-editor__select__value-container {
+		padding: 2px 10px 2px 15px;
+	}
+
+	.tribe-editor__select__single-value {
+		margin: 0;
+		max-width: calc(100% - 15px);
+		font-size: 16px;
+		line-height: 1.5;
+	}
+
+	svg.tribe-editor__select__dropdown-indicator {
+		fill: #555D66;
+	}
+
+	.tribe-editor__select__menu {
+		margin: 0;
+		border: 1px solid #E1E3E6;
+		border-top: none;
+		border-radius: 0;
+		border-bottom-left-radius: 3px;
+		border-bottom-right-radius: 3px;
+		box-shadow: none;
+		transform: translateY(-7px);
+	}
+
+	.tribe-editor__select__menu-list {
+		padding: 0;
+	}
+
+	.tribe-editor__select__option {
+		font-size: 16px;
+		line-height: 1.5;
+		padding: 3px 15px;
+
+		&--is-focused {
+			background-color: #E7F5FA;
+		}
+
+		&--is-selected {
+			background-color: #11A0D2;
+		}
+	}
+}

--- a/plugins/events-pro/src/modules/blocks/additional-fields/elements/edit-container/element.js
+++ b/plugins/events-pro/src/modules/blocks/additional-fields/elements/edit-container/element.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	Heading,
+	Paragraph,
+} from '@moderntribe/common/elements';
+import './style.pcss';
+
+const EditContainer = ( { name, children, className } ) => (
+	<div className={ classNames( 'tribe-editor__additional-fields__edit', className ) }>
+		<div className="tribe-editor__aditional-fields__content">
+			<Heading level={ 2 } className="tribe-editor__additional-fields__edit-title">
+				{ name }
+			</Heading>
+			<Paragraph>{ children }</Paragraph>
+		</div>
+	</div>
+);
+
+EditContainer.propTypes = {
+	name: PropTypes.string.isRequired,
+	children: PropTypes.node.isRequired,
+};
+
+export default EditContainer;

--- a/plugins/events-pro/src/modules/blocks/additional-fields/elements/edit-container/style.pcss
+++ b/plugins/events-pro/src/modules/blocks/additional-fields/elements/edit-container/style.pcss
@@ -1,0 +1,91 @@
+.tribe-editor__additional-fields__edit {
+	position: relative;
+
+	&:before {
+		content: '';
+		display: block;
+		position: absolute;
+		background: #F8F9F9;
+		left: -28px;
+		right: -28px;
+		top: -14px;
+		bottom: -14px;
+		z-index: 1;
+	}
+}
+
+.tribe-editor__aditional-fields__content {
+	z-index: 2;
+	position: relative;
+
+	input[type="text"],
+	input[type="url"],
+	textarea {
+		border: 1px solid #E1E3E6;
+		border-radius: 4px;
+		font-family: 'Helvetica', 'Arial', 'sans-serif';
+		font-weight: normal;
+		/* 16pt */
+		font-size: 1rem;
+		padding: 10px 15px;
+		width: 100%;
+		margin: 3px 0;
+	}
+
+	input[type="checkbox"],
+	input[type="radio"] {
+		margin-top: 0;
+		margin-right: 5px;
+		border: 1px solid #E1E3E6;
+
+		&:focus {
+			/* Add important to remove styles from gutenberg */
+			box-shadow: none !important;
+		}
+	}
+
+	input[type="checkbox"] {
+		&:checked {
+			border-color: #E1E3E6;
+			background-color: #FFF;
+			&:before {
+				color: #009FD4;
+				margin: -3px 0 0 -4px;
+			}
+		}
+	}
+
+	input[type="radio"] {
+		&:checked {
+			border-color: #E1E3E6;
+			background-color: #FFF;
+			&:before {
+				background-color: #009FD4;
+				margin: 3px 0 0 3px;
+				width: 8px;
+				height: 8px;
+			}
+		}
+	}
+}
+
+.tribe-editor__additional-fields__edit-title {
+	line-height: 1;
+	margin: 10px 0;
+}
+
+.tribe-editor__additional-fields__edit--horizontal-fields {
+	width: 100%;
+	font-family: 'Helvetica', 'Arial', 'sans-serif';
+	font-weight: normal;
+	/* 16pt */
+	font-size: 1rem;
+	margin: 3px 0;
+
+	label {
+		font-family: inherit;
+		font-weight: inherit;
+		font-size: inherit;
+		margin-right: 15px;
+	}
+}

--- a/plugins/events-pro/src/modules/blocks/additional-fields/elements/index.js
+++ b/plugins/events-pro/src/modules/blocks/additional-fields/elements/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 export { default as Preview } from './preview/element';
+export { default as EditContainer } from './edit-container/element';

--- a/plugins/events-pro/src/modules/blocks/additional-fields/index.js
+++ b/plugins/events-pro/src/modules/blocks/additional-fields/index.js
@@ -12,11 +12,17 @@ import {
 	EditContainer,
 } from './elements';
 
-import { Placeholder } from '@moderntribe/common/elements';
+import { Placeholder, Select } from '@moderntribe/common/elements';
 
 /**
  * Module Code
  */
+
+const options = [
+	{ value: 'chocolate', label: 'Chocolate' },
+	{ value: 'strawberry', label: 'Strawberry' },
+	{ value: 'vanilla', label: 'Vanilla' }
+];
 
 export default {
 	id: 'additional-fields',
@@ -54,15 +60,7 @@ export default {
 					<label htmlFor="claws">Claws</label>
 				</fieldset>
 				<input className="" type="url" name="url" id="url" />
-				<select id="pet-select">
-					<option value="">--Please choose an option--</option>
-					<option value="dog">Dog</option>
-					<option value="cat">Cat</option>
-					<option value="hamster">Hamster</option>
-					<option value="parrot">Parrot</option>
-					<option value="spider">Spider</option>
-					<option value="goldfish">Goldfish</option>
-				</select>
+				<Select options={ options } />
 				<fieldset className="tribe-editor__additional-fields__edit--horizontal-fields">
 					<input type="radio" id="huey" name="drone" value="huey" checked />
 					<label htmlFor="huey">Huey</label>

--- a/plugins/events-pro/src/modules/blocks/additional-fields/index.js
+++ b/plugins/events-pro/src/modules/blocks/additional-fields/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import React, { Fragment } from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -8,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	Preview,
+	EditContainer,
 } from './elements';
 
 import { Placeholder } from '@moderntribe/common/elements';
@@ -33,12 +35,44 @@ export default {
 
 	attributes: {},
 	edit: () => (
-		<div>
+		<Fragment>
 			<Placeholder>Add refreshments</Placeholder>
 			<Preview name={ 'Refreshments' }>
 				consectetur ea est laboris sint <a href="#">in aliqua incididunt</a> asdas asdas
 			</Preview>
-		</div>
+			<EditContainer name={ 'Refreshments' }>
+				<input className="" type="text" />
+				<textarea rows={ 5 } className="tribe-editor__additional-fields__edit-input--large">
+					fugiat amet proident occaecat dolore non dolore tempor sunt anim ut incididunt est
+				</textarea>
+				<fieldset className="tribe-editor__additional-fields__edit--horizontal-fields">
+					<input type="checkbox" id="scales" name="feature" value="scales" checked />
+					<label htmlFor="scales">Scales</label>
+					<input type="checkbox" id="horns" name="feature" value="horns" />
+					<label htmlFor="horns">Horns</label>
+					<input type="checkbox" id="claws" name="feature" value="claws" />
+					<label htmlFor="claws">Claws</label>
+				</fieldset>
+				<input className="" type="url" name="url" id="url" />
+				<select id="pet-select">
+					<option value="">--Please choose an option--</option>
+					<option value="dog">Dog</option>
+					<option value="cat">Cat</option>
+					<option value="hamster">Hamster</option>
+					<option value="parrot">Parrot</option>
+					<option value="spider">Spider</option>
+					<option value="goldfish">Goldfish</option>
+				</select>
+				<fieldset className="tribe-editor__additional-fields__edit--horizontal-fields">
+					<input type="radio" id="huey" name="drone" value="huey" checked />
+					<label htmlFor="huey">Huey</label>
+					<input type="radio" id="dewey" name="drone" value="dewey" />
+					<label htmlFor="dewey">Dewey</label>
+					<input type="radio" id="louie" name="drone" value="louie" />
+					<label htmlFor="louie">Louie</label>
+				</fieldset>
+			</EditContainer>
+		</Fragment>
 	),
 	save: () => null,
 };


### PR DESCRIPTION
- Create Edit Container for fields
- Add styles for the different type of inputs used on the container

This PR requires: https://github.com/moderntribe/events-gutenberg/pull/398

Also note that the markup used on: 

- https://github.com/moderntribe/events-gutenberg/blob/411329923d2bf88f5aa1eacbd42d2545b3681b3a/plugins/events-pro/src/modules/blocks/additional-fields/index.js#L49-L72

Is only for demo purposes it's going to be removed on next PR with real components instead.