### PR TITLE
Make sure Icon is a component and not an SVG

### DIFF
--- a/plugins/events-pro/src/modules/blocks/recurrence-exception/index.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence-exception/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import EventException from './container';
-import { TEC } from '@moderntribe/common/icons';
+import { BlockIcon } from '@moderntribe/common/elements';
 
 /**
  * Module Code
@@ -24,7 +24,7 @@ export default {
 		'Add exceptions to your event.',
 		'events-gutenberg'
 	),
-	icon: TEC,
+	icon: BlockIcon,
 	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 

--- a/plugins/events-pro/src/modules/blocks/recurrence-rule/index.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence-rule/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import EventRecurring from './container';
-import { TEC } from '@moderntribe/common/icons';
+import { BlockIcon } from '@moderntribe/common/elements';
 
 /**
  * Module Code
@@ -24,7 +24,7 @@ export default {
 		'Add recurrence to your event.',
 		'events-gutenberg'
 	),
-	icon: TEC,
+	icon: BlockIcon,
 	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 

--- a/plugins/events-pro/src/modules/blocks/recurrence/index.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence/index.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import EventRecurring from './container';
-import { TEC } from '@moderntribe/common/icons';
+import { BlockIcon } from '@moderntribe/common/elements';
 
 /**
  * Module Code
@@ -24,7 +24,7 @@ export default {
 		'Entry for recurrence',
 		'events-gutenberg'
 	),
-	icon: TEC,
+	icon: BlockIcon,
 	category: 'tribe-events',
 	keywords: [ 'event', 'events-gutenberg', 'tribe' ],
 


### PR DESCRIPTION
Update recurrence block component to make sure the icon of each block is a component and not an SVG

**Image**
- http://p.tri.be/eDA9ye

**Error**

```js
TypeError: Cannot read property 'styles' of undefined
    at __webpack_exports__.default (webpack-internal:///../common/src/modules/icons/tec.svg:22:26)
    at http://recurrence.local/wp-content/plugins/gutenberg/build/editor/index.js?ver=1540870091:50:75362
    at Kr (http://recurrence.local/wp-content/plugins/gutenberg/build/editor/index.js?ver=1540870091:50:75526)
    at yh (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:95:430)
    at lg (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:120:88)
    at mg (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:120:386)
    at gc (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:127:202)
    at vb (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:126:230)
    at ub (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:126:65)
    at zd (http://recurrence.local/wp-content/plugins/gutenberg/vendor/react-dom.min.82e21c65.js:124:449)
```