### PR TITLE
Prevent updates of attributes with same data

### DIFF
--- a/plugins/events-pro/src/modules/blocks/recurrence-exception/index.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence-exception/index.js
@@ -22,7 +22,7 @@ export default {
 	title: __( 'Exception', 'events-gutenberg' ),
 	description: __(
 		'Add exceptions to your event.',
-		'events-gutenberg'
+		'events-gutenberg',
 	),
 	icon: BlockIcon,
 	category: 'tribe-events',
@@ -32,14 +32,6 @@ export default {
 
 	supports: {
 		html: false,
-	},
-
-	attributes: {
-		exceptions: {
-			type: 'string',
-			source: 'meta',
-			meta: '_tribe_blocks_recurrence_exclusions',
-		},
 	},
 
 	edit: EventException,

--- a/plugins/events-pro/src/modules/blocks/recurrence-rule/index.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence-rule/index.js
@@ -34,14 +34,6 @@ export default {
 		html: false,
 	},
 
-	attributes: {
-		rules: {
-			type: 'string',
-			source: 'meta',
-			meta: '_tribe_blocks_recurrence_rules',
-		},
-	},
-
 	edit: EventRecurring,
 
 	save( props ) {

--- a/plugins/events-pro/src/modules/blocks/recurrence/template.js
+++ b/plugins/events-pro/src/modules/blocks/recurrence/template.js
@@ -72,6 +72,7 @@ export default class RecurringEntry extends PureComponent {
 					setAttributes={ this.props.setAttributes }
 					clientId={ this.props.clientId }
 					metaField="exceptions"
+					current={ this.props.attributes.exceptions }
 					selector={ exception.selectors.getExceptions }
 					listeners={ [
 						exception.types.ADD_EXCEPTION,
@@ -85,6 +86,7 @@ export default class RecurringEntry extends PureComponent {
 					clientId={ this.props.clientId }
 					metaField="rules"
 					selector={ recurring.selectors.getRules }
+					current={ this.props.attributes.rules }
 					listeners={ [
 						recurring.types.ADD_RULE,
 						recurring.types.EDIT_RULE,

--- a/plugins/events-pro/src/modules/data/shared/sync.js
+++ b/plugins/events-pro/src/modules/data/shared/sync.js
@@ -11,16 +11,21 @@ export function* serialize( payload ) {
 	return yield call( [ JSON, 'stringify' ], payload );
 }
 
-export function* sync( { selector, metaField, setAttributes } ) {
+export function* sync( { selector, metaField, setAttributes, current } ) {
 	const state = yield select( selector );
 	const payload = yield call( serialize, state );
+	
+	if ( current === payload ) {
+		return;
+	}
+
 	yield call( setAttributes, {
 		[ metaField ]: payload,
 	} );
 }
 
-export function* initialize( { listeners, selector, clientId, metaField, setAttributes } ) {
-	const syncSaga = yield takeLatest( listeners, sync, { selector, metaField, setAttributes } );
+export function* initialize( { listeners, selector, clientId, metaField, setAttributes, current } ) {
+	const syncSaga = yield takeLatest( listeners, sync, { selector, metaField, setAttributes, current } );
 
 	while ( true ) {
 		const action = yield take( CANCEL_SYNC );

--- a/plugins/events-pro/src/modules/elements/attribute-sync/element.js
+++ b/plugins/events-pro/src/modules/elements/attribute-sync/element.js
@@ -20,6 +20,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 			clientId: ownProps.clientId,
 			selector: ownProps.selector,
 			metaField: ownProps.metaField,
+			current: ownProps.current,
 		} ),
 		cancel: () => dispatch( {
 			type: sync.CANCEL_SYNC,


### PR DESCRIPTION
- Avoid updates to the attributes if the values are the same to prevent the call to `setAttributes` when attributes of the block hasn't changed from last time.
- Remove `attributes` from child blocks as the data is consumed from the store

🎫 https://central.tri.be/issues/113421