### PR TITLE
Add Queue status `admin_ajax` response

### DIFF
--- a/plugins/events-pro/src/Tribe/Assets.php
+++ b/plugins/events-pro/src/Tribe/Assets.php
@@ -67,8 +67,8 @@ class Tribe__Gutenberg__Events_Pro__Assets {
 			)
 		);
 
-		add_filter( 'tribe_events_gutenberg_js_config', array( $this, 'set_editor_defaults' ), 10 );
-
+		add_filter( 'tribe_events_gutenberg_js_config', array( $this, 'set_editor_defaults' ) );
+		add_filter( 'tribe_events_gutenberg_js_config', array( $this, 'add_queue_status_nonce' ) );
 	}
 
 	/**
@@ -133,9 +133,36 @@ class Tribe__Gutenberg__Events_Pro__Assets {
 		}
 
 		$js_config['editor_defaults'] = $defaults;
-
+		
 		return $js_config;
-
+	}
+	
+	/**
+	 * Attach the queue status nonce into the tribe_js_config variable
+	 *
+	 * @since TBD
+	 *
+	 * @param $js_config
+	 *
+	 * @return mixed
+	 */
+	public function add_queue_status_nonce( $js_config ) {
+		if ( ! isset( $js_config['rest'] ) ) {
+			$js_config['rest'] = array();
+		}
+		
+		if ( ! isset( $js_config['rest']['nonce'] ) ) {
+			$js_config['rest']['nonce'] = array();
+		}
+		
+		$js_config['rest']['nonce'] = array_merge(
+			$js_config['rest']['nonce'],
+			array(
+				'queue_status_nonce' => tribe( 'gutenberg.events-pro.recurrence.queue-status' )->get_ajax_nonce(),
+			)
+		);
+		
+		return $js_config;
 	}
 
 }

--- a/plugins/events-pro/src/Tribe/Provider.php
+++ b/plugins/events-pro/src/Tribe/Provider.php
@@ -22,6 +22,7 @@ class Tribe__Gutenberg__Events_Pro__Provider extends tad_DI52_ServiceProvider {
 
 		$this->container->singleton( 'gutenberg.events-pro.meta', 'Tribe__Gutenberg__Events_Pro__Meta' );
 		$this->container->singleton( 'gutenberg.events-pro.recurrence.provider', 'Tribe__Gutenberg__Events_Pro__Recurrence__Provider' );
+		$this->container->singleton( 'gutenberg.events-pro.recurrence.queue-status', 'Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status' );
 
 		$this->hook();
 
@@ -39,6 +40,7 @@ class Tribe__Gutenberg__Events_Pro__Provider extends tad_DI52_ServiceProvider {
 		// Initialize the correct Singletons
 		tribe( 'gutenberg.events-pro.assets' );
 		tribe( 'gutenberg.events-pro.recurrence.provider' )->hook();
+		tribe(  'gutenberg.events-pro.recurrence.queue-status' )->hook();
 		add_action( 'init', tribe_callback( 'gutenberg.events-pro.meta', 'register' ), 15 );
 	}
 

--- a/plugins/events-pro/src/Tribe/Recurrence/Queue_Status.php
+++ b/plugins/events-pro/src/Tribe/Recurrence/Queue_Status.php
@@ -33,7 +33,7 @@ class Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status {
 		) {
 			$response = $this->process( $post_id );
 		}
-		$this->response( $response );
+		exit( $this->response( $response ) );
 	}
 	
 	/**
@@ -90,8 +90,10 @@ class Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status {
 	 * @since TBD
 	 *
 	 * @param $data
+	 * @return string
 	 */
 	public function response( $data ) {
-		exit( json_encode( $data ) );
+		$encoded = json_encode( $data );
+		return false === $encoded ? '' : $encoded;
 	}
 }

--- a/plugins/events-pro/src/Tribe/Recurrence/Queue_Status.php
+++ b/plugins/events-pro/src/Tribe/Recurrence/Queue_Status.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Class Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status
+ *
+ * @since TBD
+ */
+class Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status {
+	
+	/**
+	 * The Queue_Realtime constructor method.
+	 */
+	public function hook() {
+		if ( ! class_exists( 'Tribe__Events__Ajax__Operations' ) ) {
+			return;
+		}
+		add_action( 'wp_ajax_gutenberg_events_pro_recurrence_queue', array( $this, 'ajax' ) );
+	}
+	
+	/**
+	 * Method used to reply back into the ajax admin request
+	 *
+	 * @since TBD
+	 */
+	public function ajax() {
+		$post_id = (int) tribe_get_request_var( 'post_id', 0 );
+		$nonce   = sanitize_text_field( tribe_get_request_var( 'recurrence_queue_status_nonce', '' ) );
+		
+		$response = false;
+		if (
+			tribe_is_recurring_event( $post_id )
+			&& wp_verify_nonce( $nonce, $this->get_ajax_action() )
+		) {
+			$response = $this->process( $post_id );
+		}
+		$this->response( $response );
+	}
+	
+	/**
+	 * Function used to trigger que recurrence Queue
+	 *
+	 * @since TBD
+	 *
+	 * @param $post_id
+	 *
+	 * @return array
+	 */
+	public function process( $post_id ) {
+		$queue = new Tribe__Events__Pro__Recurrence__Queue( $post_id );
+		
+		$is_empty = $queue->is_empty();
+		if ( ! $is_empty ) {
+			$queue_processor = Tribe__Events__Pro__Main::instance()->queue_processor;
+			if ( null !== $queue_processor ) {
+				$queue_processor->process_batch( $post_id );
+			}
+		}
+		
+		return array(
+			'done'       => $is_empty,
+			'percentage' => $is_empty ? 100 : $queue->progress_percentage(),
+		);
+	}
+	
+	/**
+	 * Return the nonce for the ajax action
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_ajax_nonce() {
+		return wp_create_nonce( $this->get_ajax_action() );
+	}
+	
+	/**
+	 * Name of the action used on the page to create the nonce
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_ajax_action() {
+		return 'gutenberg_events_pro_recurrence_queue_status' . get_current_user_id();
+	}
+	
+	/**
+	 * Exit and return the response as json encoded string
+	 *
+	 * @since TBD
+	 *
+	 * @param $data
+	 */
+	public function response( $data ) {
+		exit( json_encode( $data ) );
+	}
+}


### PR DESCRIPTION
Make an `admin_ajax` response available to keep track and trigger the Queue on events without leaving the page, specifically for large series of recurrence events, ideally a response to this should be every 0.5 to keep consistency with old UI if the series hasn't been completed.

Usage example: 

```js
const data = new FormData();
data.append('action', 'gutenberg_events_pro_recurrence_queue');
data.append('recurrence_queue_status_nonce', tribe_js_config.rest.nonce.queue_status_nonce );
data.append('post_id',  wp.data.select( 'core/editor' ).getCurrentPostId() );

const params = {
  method: 'POST',
  credentials: 'same-origin',
  body: data,
};

// Sample request.
fetch( ajaxurl, params )
.then( (r) => r.json() )
.then( (c) => console.log( c ) );
````

Be aware that: 

- `ajaxurl` is a global localized by WP
- `tribe_js_config.rest.nonce.queue_status_nonce` is a new localized variable with this PR.
- `wpSelect( 'core/editor' ).getCurrentPostId()` function provided by Gutenberg to get the current post ID.

A `false` is returned if the response fails or if the event is non a recurrent event, otherwise an associative array is returned with the following shape: 

```js
{
    completed: true / false
    percentage: [0, 100] 
}
```

This one is available as an Object after parsing into a JSON object.