### PR TITLE
Remove recurrence keys if `_EventRecurrence` is deleted

### DIFF
--- a/plugins/events-pro/src/Tribe/Meta.php
+++ b/plugins/events-pro/src/Tribe/Meta.php
@@ -14,8 +14,10 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 	 * @return void
 	 */
 	public function register() {
-		register_meta( 'post', '_tribe_blocks_recurrence_rules', tribe( 'gutenberg.events.meta' )->text() );
-		register_meta( 'post', '_tribe_blocks_recurrence_exclusions', tribe( 'gutenberg.events.meta' )->text() );
+		/** @var Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta $blocks_meta */
+		$blocks_meta = tribe( 'gutenberg.events-pro.recurrence.blocks-meta' );
+		register_meta( 'post', $blocks_meta->get_rules_key(), tribe( 'gutenberg.events.meta' )->text() );
+		register_meta( 'post', $blocks_meta->get_exclusions_key(), tribe( 'gutenberg.events.meta' )->text() );
 		
 		add_filter( 'get_post_metadata', array( $this, 'filter_going_fields' ), 15, 4 );
 		add_action( 'deleted_post_meta', array( $this, 'remove_recurrence_meta' ), 10, 3  );
@@ -34,9 +36,11 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 	 * @return array|null|string The attachment metadata value, array of values, or null.
 	 */
 	public function filter_going_fields( $value, $post_id, $meta_key, $single ) {
+		/** @var Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta $blocks_meta */
+		$blocks_meta = tribe( 'gutenberg.events-pro.recurrence.blocks-meta' );
 		$valid_keys = array(
-			'_tribe_blocks_recurrence_rules',
-			'_tribe_blocks_recurrence_exclusions',
+			$blocks_meta->get_exclusions_key(),
+			$blocks_meta->get_rules_key(),
 		);
 		
 		if ( ! in_array( $meta_key, $valid_keys ) ) {
@@ -50,8 +54,8 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 		}
 		
 		$keys = array(
-			'_tribe_blocks_recurrence_rules'      => 'rules',
-			'_tribe_blocks_recurrence_exclusions' => 'exclusions',
+			$blocks_meta->get_rules_key() => 'rules',
+			$blocks_meta->get_exclusions_key() => 'exclusions',
 		);
 		$key  = $keys[ $meta_key ];
 		if ( empty( $recurrence[ $key ] ) ) {
@@ -100,8 +104,10 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 		if ( '_EventRecurrence' !== $meta_key ) {
 			return;
 		}
-		delete_post_meta( $object_id, '_tribe_blocks_recurrence_rules' );
-		delete_post_meta( $object_id, '_tribe_blocks_recurrence_exclusions' );
+		/** @var Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta $blocks_meta */
+		$blocks_meta = tribe( 'gutenberg.events-pro.recurrence.blocks-meta' );
+		delete_post_meta( $object_id, $blocks_meta->get_rules_key() );
+		delete_post_meta( $object_id, $blocks_meta->get_exclusions_key() );
 	}
 	
 	/**

--- a/plugins/events-pro/src/Tribe/Meta.php
+++ b/plugins/events-pro/src/Tribe/Meta.php
@@ -120,8 +120,8 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 	 * @return bool
 	 */
 	public function remove_recurrence_classic_meta( $show_meta ) {
-		$is_classic_editor = tribe_get_request_var('classic-editor', null );
-		
+		$is_classic_editor = tribe_get_request_var( 'classic-editor', null );
+
 		return $is_classic_editor === null ? false : $show_meta;
 	}
 }

--- a/plugins/events-pro/src/Tribe/Meta.php
+++ b/plugins/events-pro/src/Tribe/Meta.php
@@ -18,6 +18,8 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 		register_meta( 'post', '_tribe_blocks_recurrence_exclusions', tribe( 'gutenberg.events.meta' )->text() );
 		
 		add_filter( 'get_post_metadata', array( $this, 'filter_going_fields' ), 15, 4 );
+		add_action( 'deleted_post_meta', array( $this, 'remove_recurrence_meta' ), 10, 3  );
+		add_filter( 'tribe_pro_show_recurrence_meta_box', array( $this, 'remove_recurrence_classic_meta' ) );
 	}
 	
 	/**
@@ -82,5 +84,40 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 		$query = "SELECT meta_value FROM $wpdb->postmeta WHERE post_id = %d AND meta_key = %s";
 		
 		return $wpdb->get_var( $wpdb->prepare( $query, $post_id, $meta_key ) );
+	}
+	
+	/**
+	 * Removes the meta keys that maps into the classic editor when the `_EventRecurrence` is
+	 * removed.
+	 *
+	 * @since TBD
+	 *
+	 * @param $meta_id
+	 * @param $object_id
+	 * @param $meta_key
+	 */
+	public function remove_recurrence_meta( $meta_id, $object_id, $meta_key ) {
+		if ( '_EventRecurrence' !== $meta_key ) {
+			return;
+		}
+		delete_post_meta( $object_id, '_tribe_blocks_recurrence_rules' );
+		delete_post_meta( $object_id, '_tribe_blocks_recurrence_exclusions' );
+	}
+	
+	/**
+	 * Remove the recurrence meta box if classic-editor is set
+	 *
+	 * @since TBD
+	 *
+	 * @param $show_meta
+	 *
+	 * @return bool
+	 */
+	public function remove_recurrence_classic_meta( $show_meta ) {
+		$is_classic_editor = tribe_get_request_var('classic-editor', null );
+		if ( $is_classic_editor === null ) {
+			return false;
+		}
+		return $show_meta;
 	}
 }

--- a/plugins/events-pro/src/Tribe/Meta.php
+++ b/plugins/events-pro/src/Tribe/Meta.php
@@ -21,7 +21,7 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 		
 		add_filter( 'get_post_metadata', array( $this, 'filter_going_fields' ), 15, 4 );
 		add_action( 'deleted_post_meta', array( $this, 'remove_recurrence_meta' ), 10, 3  );
-		add_filter( 'tribe_pro_show_recurrence_meta_box', array( $this, 'remove_recurrence_classic_meta' ) );
+		add_filter( 'tribe_events_pro_show_recurrence_meta_box', array( $this, 'remove_recurrence_classic_meta' ) );
 	}
 	
 	/**

--- a/plugins/events-pro/src/Tribe/Meta.php
+++ b/plugins/events-pro/src/Tribe/Meta.php
@@ -115,9 +115,7 @@ class Tribe__Gutenberg__Events_Pro__Meta {
 	 */
 	public function remove_recurrence_classic_meta( $show_meta ) {
 		$is_classic_editor = tribe_get_request_var('classic-editor', null );
-		if ( $is_classic_editor === null ) {
-			return false;
-		}
-		return $show_meta;
+		
+		return $is_classic_editor === null ? false : $show_meta;
 	}
 }

--- a/plugins/events-pro/src/Tribe/Provider.php
+++ b/plugins/events-pro/src/Tribe/Provider.php
@@ -23,6 +23,7 @@ class Tribe__Gutenberg__Events_Pro__Provider extends tad_DI52_ServiceProvider {
 		$this->container->singleton( 'gutenberg.events-pro.meta', 'Tribe__Gutenberg__Events_Pro__Meta' );
 		$this->container->singleton( 'gutenberg.events-pro.recurrence.provider', 'Tribe__Gutenberg__Events_Pro__Recurrence__Provider' );
 		$this->container->singleton( 'gutenberg.events-pro.recurrence.queue-status', 'Tribe__Gutenberg__Events_Pro__Recurrence__Queue_Status' );
+		$this->container->singleton( 'gutenberg.events-pro.recurrence.blocks-meta', 'Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta' );
 
 		$this->hook();
 

--- a/plugins/events-pro/src/Tribe/Provider.php
+++ b/plugins/events-pro/src/Tribe/Provider.php
@@ -40,7 +40,7 @@ class Tribe__Gutenberg__Events_Pro__Provider extends tad_DI52_ServiceProvider {
 		// Initialize the correct Singletons
 		tribe( 'gutenberg.events-pro.assets' );
 		tribe( 'gutenberg.events-pro.recurrence.provider' )->hook();
-		tribe(  'gutenberg.events-pro.recurrence.queue-status' )->hook();
+		tribe( 'gutenberg.events-pro.recurrence.queue-status' )->hook();
 		add_action( 'init', tribe_callback( 'gutenberg.events-pro.meta', 'register' ), 15 );
 	}
 

--- a/plugins/events-pro/src/Tribe/Recurrence/Blocks_Meta.php
+++ b/plugins/events-pro/src/Tribe/Recurrence/Blocks_Meta.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Class Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta
+ *
+ * @since TBD
+ */
+class Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta {
+	protected $rules_key = '_tribe_blocks_recurrence_rules';
+	protected $exclusions_key = '_tribe_blocks_recurrence_exclusions';
+	
+	/**
+	 * Meta key used to get the rules associated with the recurrence on the new UI
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_rules_key() {
+		return $this->rules_key;
+	}
+	
+	/**
+	 * Return the meta key used to get the exclusions in a post.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_exclusions_key() {
+		return $this->exclusions_key;
+	}
+}

--- a/plugins/events-pro/src/Tribe/Recurrence/Provider.php
+++ b/plugins/events-pro/src/Tribe/Recurrence/Provider.php
@@ -24,8 +24,10 @@ class Tribe__Gutenberg__Events_Pro__Recurrence__Provider {
 	public function to_classic_format( $event_id ) {
 		/** @var Tribe__Gutenberg__Events_Pro__Meta $meta */
 		$meta       = tribe( 'gutenberg.events-pro.meta' );
-		$rules      = json_decode( $meta->get_value( $event_id, '_tribe_blocks_recurrence_rules' ), true );
-		$exclusions = json_decode( $meta->get_value( $event_id, '_tribe_blocks_recurrence_exclusions' ), true );
+		/** @var Tribe__Gutenberg__Events_Pro__Recurrence__Blocks_Meta $blocks_meta */
+		$blocks_meta = tribe( 'gutenberg.events-pro.recurrence.blocks-meta' );
+		$rules      = json_decode( $meta->get_value( $event_id, $blocks_meta->get_rules_key() ), true );
+		$exclusions = json_decode( $meta->get_value( $event_id, $blocks_meta->get_exclusions_key() ), true );
 		
 		// Don't do anything if the block does not have any data.
 		if ( is_null( $rules ) ) {


### PR DESCRIPTION
Remove the keys associated with the event:

- `_tribe_blocks_recurrence_exclusions`
- `_tribe_blocks_recurrence_rules`

If the event removes the `_EventRecurrence` meta key as is no longer a 
recurrent event.

Removes the recurrence meta box from the editor as well if
`classic-editor` is set.